### PR TITLE
feat(auth): add register function to Auth context

### DIFF
--- a/meClub/src/features/auth/useAuth.js
+++ b/meClub/src/features/auth/useAuth.js
@@ -67,6 +67,17 @@ export function AuthProvider({ children }) {
     return usuario;
   };
 
+  const register = async (params) => {
+    const data = await api.post('/auth/register', params);
+    const { token, usuario } = data || {};
+    if (!token || !usuario) throw new Error('Respuesta de registro inválida');
+
+    await storage.setItem(tokenKey, token);
+    await storage.setItem(userKey, JSON.stringify(usuario));
+    setUser(usuario);
+    return usuario;
+  };
+
   const logout = async () => {
     await storage.delItem(tokenKey);
     await storage.delItem(userKey);
@@ -85,6 +96,7 @@ export function AuthProvider({ children }) {
     isLogged: !!user,
     isClub,
     login,
+    register,
     logout,
   }), [user, ready, isClub]);
 


### PR DESCRIPTION
## Summary
- add `register` endpoint support storing auth token and user
- expose `register` through auth context

## Testing
- `npm test --prefix meClub` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ba03bd8aa4832f88a4f7de95a17242