### PR TITLE
feat: add club summary endpoint and improve api error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# meClub
+
+## Resumen de club
+
+El backend expone la ruta `GET /api/clubes/:club_id/resumen`.
+Devuelve un objeto `data` con los siguientes campos:
+
+- `courtsAvailable`: cantidad de canchas registradas para el club.
+- `reservasHoy`: reservas del día actual.
+- `reservasSemana`: reservas realizadas en la semana actual.
+- `economiaMes`: monto total de reservas del mes en curso.
+
+Ejemplo:
+
+```bash
+curl http://localhost:3006/api/clubes/1/resumen
+```
+
+```json
+{
+  "data": {
+    "courtsAvailable": 3,
+    "reservasHoy": 0,
+    "reservasSemana": 5,
+    "economiaMes": 12000
+  }
+}
+```
+
+

--- a/backend/routes/clubes.routes.js
+++ b/backend/routes/clubes.routes.js
@@ -76,6 +76,21 @@ router.get('/publico/:club_id', async (req, res) => {
   }
 });
 
+// ---------------- Resumen por club
+router.get('/:club_id/resumen', async (req, res) => {
+  try {
+    const { club_id } = req.params;
+    const club = await ClubesModel.obtenerClubPorId(club_id);
+    if (!club) return res.status(404).json({ mensaje: 'Club no encontrado' });
+
+    const data = await ClubesModel.obtenerResumen(club_id);
+    res.json({ data });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ mensaje: 'Error interno del servidor' });
+  }
+});
+
 // ---------------- Panel club: reservas por cancha/fecha
 router.get('/canchas/:cancha_id/reservas', verifyToken, requireRole('club'), async (req, res) => {
   try {

--- a/meClub/src/lib/api.js
+++ b/meClub/src/lib/api.js
@@ -48,20 +48,20 @@ export const authApi = {
 export async function getClubSummary({ clubId }) {
   try {
     const { data } = await api.get(`/clubes/${clubId}/resumen`);
+    if (!data) {
+      // Backend no respondió correctamente
+      return { courtsAvailable: 0, reservasHoy: 0, reservasSemana: 0, economiaMes: 0 };
+    }
     // Esperado: { courtsAvailable, reservasHoy, reservasSemana, economiaMes }
     return {
-      courtsAvailable: data?.courtsAvailable ?? 3,
-      reservasHoy: data?.reservasHoy ?? 0,
-      reservasSemana: data?.reservasSemana ?? 0,
-      economiaMes: data?.economiaMes ?? 0,
+      courtsAvailable: data.courtsAvailable ?? 0,
+      reservasHoy: data.reservasHoy ?? 0,
+      reservasSemana: data.reservasSemana ?? 0,
+      economiaMes: data.economiaMes ?? 0,
     };
-  } catch {
-    // Fallback
-    return {
-      courtsAvailable: 3,
-      reservasHoy: 8,
-      reservasSemana: 24,
-      economiaMes: 14520,
-    };
+  } catch (err) {
+    console.warn('getClubSummary error', err);
+    // Si el backend no responde devolvemos valores en cero
+    return { courtsAvailable: 0, reservasHoy: 0, reservasSemana: 0, economiaMes: 0 };
   }
 }


### PR DESCRIPTION
## Summary
- add club summary model and route to expose `/api/clubes/:club_id/resumen`
- handle backend errors in `getClubSummary` and remove placeholder values
- document how to obtain the club summary in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm test` in backend *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ba4cff50c4832fa16a6b784335d47e