### PR TITLE
refactor: enforce JWT secret and return next in auth middleware

### DIFF
--- a/backend/middleware/auth.middleware.js
+++ b/backend/middleware/auth.middleware.js
@@ -1,16 +1,21 @@
 const jwt = require('jsonwebtoken');
 
+const { JWT_SECRET } = process.env;
+if (!JWT_SECRET) {
+  throw new Error('JWT_SECRET environment variable is not set');
+}
+
 const verifyToken = (req, res, next) => {
   let token = req.headers['authorization'];
   if (!token) return res.status(403).json({ mensaje: 'Token no proporcionado' });
   if (token.startsWith('Bearer ')) token = token.slice(7);
 
   try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    const decoded = jwt.verify(token, JWT_SECRET);
     // Normalizador usuario_id a id
     if (!decoded.id && decoded.usuario_id) decoded.id = decoded.usuario_id;
     req.usuario = decoded;
-      next();
+    return next();
   } catch (err) {
     return res.status(401).json({ mensaje: 'Token inválido o expirado' });
   }


### PR DESCRIPTION
## Summary
- ensure JWT_SECRET is defined when loading auth middleware
- return next() after decoding token
- keep error branches returning properly

## Testing
- `npm test --prefix backend` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ba4ed4b758832f9cf2426e6c94d1bf