### PR TITLE
feat: add club loader middleware

### DIFF
--- a/backend/middleware/club.middleware.js
+++ b/backend/middleware/club.middleware.js
@@ -1,0 +1,25 @@
+const ClubesModel = require('../models/clubes.model');
+
+const getUserId = (u) => u?.id ?? u?.usuario_id;
+
+const loadClub = async (req, res, next) => {
+  try {
+    const usuarioId = getUserId(req.usuario);
+    if (!usuarioId) {
+      return res.status(403).json({ mensaje: 'Token sin identificador de usuario' });
+    }
+
+    const club = await ClubesModel.obtenerClubPorPropietario(usuarioId);
+    if (!club) {
+      return res.status(404).json({ mensaje: 'No tienes club relacionado' });
+    }
+
+    req.club = club;
+    next();
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ mensaje: 'Error interno del servidor' });
+  }
+};
+
+module.exports = loadClub;


### PR DESCRIPTION
## Summary
- add middleware to load the authenticated club into `req.club`
- refactor club routes to reuse loaded club across private endpoints

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ba50498fc8832faba178a170f1a07d