### PR TITLE
Extract datetime helpers to utils and add tests

### DIFF
--- a/backend/routes/reservas.routes.js
+++ b/backend/routes/reservas.routes.js
@@ -4,31 +4,10 @@ const router = express.Router();
 const verifyToken = require('../middleware/auth.middleware');
 const ReservasModel = require('../models/reservas.model');
 const CanchasModel = require('../models/canchas.model');
-const ClubesHorarioModel = require('../models/clubesHorario.model');
 const TarifasModel = require('../models/tarifas.model');
+const { diaSemana1a7, addHoursHHMMSS, isPastDateTime } = require('../utils/datetime');
 // helpers
 const getUserId = (u) => u?.id ?? u?.usuario_id;
-const diaSemana1a7 = (yyyy_mm_dd) => {
-  const d = new Date(`${yyyy_mm_dd}T00:00:00`);
-  if (Number.isNaN(d.getTime())) return null;
-  const dow0 = d.getUTCDay();     // 0..6
-  return dow0 === 0 ? 7 : dow0;   // 1..7 (L=1 ... D=7)
-};
-const addHoursHHMMSS = (hhmmss, hours) => {
-  const [h, m, s] = hhmmss.split(':').map(Number);
-  if ([h, m, s].some((x) => Number.isNaN(x))) return null;
-  const base = new Date(Date.UTC(1970, 0, 1, h, m, s || 0));
-  base.setUTCHours(base.getUTCHours() + Number(hours));
-  const hh = String(base.getUTCHours()).padStart(2, '0');
-  const mm = String(base.getUTCMinutes()).padStart(2, '0');
-  const ss = String(base.getUTCSeconds()).padStart(2, '0');
-  return `${hh}:${mm}:${ss}`;
-};
-const isPastDateTime = (yyyy_mm_dd, hhmmss) => {
-  const now = new Date();
-  const dt = new Date(`${yyyy_mm_dd}T${hhmmss}`);
-  return dt.getTime() < now.getTime();
-};
 // -----------------------------------------------------------------------------------------------
 
 // POST crear reserva

--- a/backend/utils/datetime.js
+++ b/backend/utils/datetime.js
@@ -1,0 +1,46 @@
+/**
+ * Helpers de fecha y hora.
+ */
+
+/**
+ * Devuelve el número de día de la semana (1=Lunes ... 7=Domingo) para una fecha ISO.
+ * @param {string} yyyy_mm_dd - Fecha en formato YYYY-MM-DD.
+ * @returns {number|null} Día de la semana (1-7) o null si la fecha es inválida.
+ */
+function diaSemana1a7(yyyy_mm_dd) {
+  const d = new Date(`${yyyy_mm_dd}T00:00:00`);
+  if (Number.isNaN(d.getTime())) return null;
+  const dow0 = d.getUTCDay(); // 0..6
+  return dow0 === 0 ? 7 : dow0; // 1..7 (L=1 ... D=7)
+}
+
+/**
+ * Suma una cantidad de horas a una hora HH:MM:SS.
+ * @param {string} hhmmss - Hora en formato HH:MM:SS.
+ * @param {number} hours - Cantidad de horas a sumar.
+ * @returns {string|null} Nueva hora HH:MM:SS o null si la entrada es inválida.
+ */
+function addHoursHHMMSS(hhmmss, hours) {
+  const [h, m, s] = hhmmss.split(':').map(Number);
+  if ([h, m, s].some((x) => Number.isNaN(x))) return null;
+  const base = new Date(Date.UTC(1970, 0, 1, h, m, s || 0));
+  base.setUTCHours(base.getUTCHours() + Number(hours));
+  const hh = String(base.getUTCHours()).padStart(2, '0');
+  const mm = String(base.getUTCMinutes()).padStart(2, '0');
+  const ss = String(base.getUTCSeconds()).padStart(2, '0');
+  return `${hh}:${mm}:${ss}`;
+}
+
+/**
+ * Indica si un día y hora dados están en el pasado respecto a la hora actual.
+ * @param {string} yyyy_mm_dd - Fecha en formato YYYY-MM-DD.
+ * @param {string} hhmmss - Hora en formato HH:MM:SS.
+ * @returns {boolean} true si la fecha y hora están en el pasado.
+ */
+function isPastDateTime(yyyy_mm_dd, hhmmss) {
+  const now = new Date();
+  const dt = new Date(`${yyyy_mm_dd}T${hhmmss}`);
+  return dt.getTime() < now.getTime();
+}
+
+module.exports = { diaSemana1a7, addHoursHHMMSS, isPastDateTime };

--- a/backend/utils/datetime.test.js
+++ b/backend/utils/datetime.test.js
@@ -1,0 +1,18 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { diaSemana1a7, addHoursHHMMSS, isPastDateTime } = require('./datetime');
+
+test('diaSemana1a7 devuelve el día correcto', () => {
+  assert.strictEqual(diaSemana1a7('2024-01-01'), 1);
+  assert.strictEqual(diaSemana1a7('2024-01-07'), 7);
+});
+
+test('addHoursHHMMSS suma horas correctamente', () => {
+  assert.strictEqual(addHoursHHMMSS('10:00:00', 2), '12:00:00');
+  assert.strictEqual(addHoursHHMMSS('23:30:00', 2), '01:30:00');
+});
+
+test('isPastDateTime detecta si está en el pasado', () => {
+  assert.strictEqual(isPastDateTime('2000-01-01', '00:00:00'), true);
+  assert.strictEqual(isPastDateTime('2999-01-01', '00:00:00'), false);
+});


### PR DESCRIPTION
## Summary
- move date helpers into `utils/datetime.js`
- import helpers into reservas routes
- add basic unit tests for datetime helpers

## Testing
- `node --test utils/datetime.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba525ab4b4832f8a09293121bc614c