### PR TITLE
refactor: redirect after login

### DIFF
--- a/meClub/src/navigation/ProtectedRoute.jsx
+++ b/meClub/src/navigation/ProtectedRoute.jsx
@@ -14,7 +14,7 @@ export default function ProtectedRoute({ children, requiredRole }) {
   const nav = useNavigation();
 
   useEffect(() => {
-    if (!ready) return;
+    if (!ready || typeof isLogged === 'undefined') return;
     if (!isLogged) {
       nav.reset({ index: 0, routes: [{ name: 'Login' }] });
     } else if (requiredRole && !hasRole(user, requiredRole)) {
@@ -22,7 +22,7 @@ export default function ProtectedRoute({ children, requiredRole }) {
     }
   }, [ready, isLogged, user, requiredRole, nav]);
 
-  if (!ready || !isLogged || (requiredRole && !hasRole(user, requiredRole))) {
+  if (!ready || typeof isLogged === 'undefined' || !isLogged || (requiredRole && !hasRole(user, requiredRole))) {
     return (
       <View style={{ flex: 1, backgroundColor: '#0e131f', alignItems: 'center', justifyContent: 'center' }}>
         <ActivityIndicator color="#2b8280" />

--- a/meClub/src/screens/LoginScreen.jsx
+++ b/meClub/src/screens/LoginScreen.jsx
@@ -36,7 +36,13 @@ const resetSchema = z.object({
 
 export default function LoginScreen() {
   const nav  = useNavigation();
-  const auth = useAuth();
+  const { login, register, user, isLogged } = useAuth();
+
+  useEffect(() => {
+    if (isLogged) {
+      nav.reset({ index: 0, routes: [{ name: 'Dashboard' }] });
+    }
+  }, [isLogged, nav, user]);
 
   // 'login' | 'register' | 'forgot' | 'reset'
   const [mode, setMode] = useState('login');
@@ -103,8 +109,7 @@ export default function LoginScreen() {
   const submitLogin = async ({ email, password }) => {
     setBusy(true); setErr(''); setOk('');
     try {
-      await auth.login({ email, password });
-      nav.reset({ index: 0, routes: [{ name: 'Dashboard' }] });
+      await login({ email, password });
     } catch (e) {
       setErr(e.message || 'Credenciales inválidas');
     } finally { setBusy(false); }
@@ -113,7 +118,7 @@ export default function LoginScreen() {
   const submitRegister = async (data) => {
     setBusy(true); setErr(''); setOk('');
     try {
-      await auth.register(data);
+      await register(data);
       nav.reset({ index: 0, routes: [{ name: 'Dashboard' }] });
     } catch (e) {
       setErr(e.message || 'No se pudo registrar');


### PR DESCRIPTION
## Summary
- navigate to Dashboard on auth state change instead of within submit handler
- gate ProtectedRoute redirects until auth is ready

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ba5874ede8832fb6aa07475fffd40a