### PR TITLE
feat(auth): return jwt on register

### DIFF
--- a/backend/controllers/auth.controller.js
+++ b/backend/controllers/auth.controller.js
@@ -43,8 +43,15 @@ exports.register = async (req, res) => {
       });
     }
 
+    const token = jwt.sign(
+      { usuario_id: nuevoUsuario.usuario_id, email: nuevoUsuario.email, rol: nuevoUsuario.rol },
+      process.env.JWT_SECRET,
+      { expiresIn: '24h' }
+    );
+
     res.status(201).json({
       mensaje: 'Usuario registrado correctamente',
+      token,
       usuario: nuevoUsuario,
       club: clubCreado,
     });

--- a/backend/tests/register.test.js
+++ b/backend/tests/register.test.js
@@ -1,0 +1,38 @@
+const assert = require('assert');
+const { register } = require('../controllers/auth.controller');
+const UsuariosModel = require('../models/usuarios.model');
+const ClubesModel = require('../models/clubes.model');
+const bcrypt = require('bcryptjs');
+
+(async () => {
+  // Preparar mocks
+  UsuariosModel.buscarPorEmail = async () => [];
+  UsuariosModel.crearUsuario = async (u) => ({
+    usuario_id: 1,
+    nombre: u.nombre,
+    apellido: u.apellido,
+    email: u.email,
+    rol: u.rol,
+  });
+  ClubesModel.crearClub = async () => null;
+  bcrypt.hash = async () => 'hash';
+
+  process.env.JWT_SECRET = 'secret';
+
+  let statusCode = 0;
+  let jsonBody = null;
+  const req = {
+    body: { nombre: 'Test', apellido: 'User', email: 'test@example.com', contrasena: '1234' },
+  };
+  const res = {
+    status(code) { statusCode = code; return this; },
+    json(obj) { jsonBody = obj; },
+  };
+
+  await register(req, res);
+
+  assert.strictEqual(statusCode, 201);
+  assert.ok(jsonBody.token, 'token should be returned');
+  assert.ok(jsonBody.usuario, 'usuario should be returned');
+  console.log('register returned { token, usuario }');
+})();

--- a/meClub/src/features/auth/useAuth.js
+++ b/meClub/src/features/auth/useAuth.js
@@ -69,13 +69,15 @@ export function AuthProvider({ children }) {
 
   const register = async (params) => {
     const data = await api.post('/auth/register', params);
-    const { token, usuario } = data || {};
-    if (!token || !usuario) throw new Error('Respuesta de registro inválida');
+    // Algunas versiones del backend pueden devolver `user` en lugar de `usuario`
+    const { token, usuario, user } = data || {};
+    const usr = usuario || user;
+    if (!token || !usr) throw new Error('Respuesta de registro inválida');
 
     await storage.setItem(tokenKey, token);
-    await storage.setItem(userKey, JSON.stringify(usuario));
-    setUser(usuario);
-    return usuario;
+    await storage.setItem(userKey, JSON.stringify(usr));
+    setUser(usr);
+    return usr;
   };
 
   const logout = async () => {


### PR DESCRIPTION
## Summary
- sign a JWT when registering users and include it in the response
- make AuthProvider resilient to `usuario`/`user` field name
- add a small test ensuring register returns `{ token, usuario }`

## Testing
- `node backend/tests/register.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba5a7a338c832f892f92f41b646537