### PR TITLE
Codex- 0.1.5925.0115

### DIFF
--- a/backend/controllers/auth.controller.js
+++ b/backend/controllers/auth.controller.js
@@ -75,7 +75,20 @@ exports.login = async (req, res) => {
       { expiresIn: '24h' }
     );
 
-    res.json({
+    // Si el usuario es un club, buscamos los datos básicos del club
+    let clubInfo = null;
+    if (usuario.rol === 'club') {
+      try {
+        const club = await ClubesModel.obtenerClubPorPropietario(usuario.usuario_id);
+        if (club) {
+          clubInfo = { club_id: club.club_id, nombre: club.nombre };
+        }
+      } catch (err) {
+        console.error('Error obteniendo club del usuario', err);
+      }
+    }
+
+    const respuesta = {
       mensaje: 'Login exitoso',
       token,
       usuario: {
@@ -85,7 +98,11 @@ exports.login = async (req, res) => {
         email: usuario.email,
         rol: usuario.rol,
       },
-    });
+    };
+
+    if (clubInfo) respuesta.club = clubInfo;
+
+    res.json(respuesta);
   } catch (error) {
     console.error('Error en login:', error);
     res.status(500).json({ mensaje: 'Error en el servidor' });

--- a/meClub/src/features/auth/useAuth.js
+++ b/meClub/src/features/auth/useAuth.js
@@ -57,14 +57,20 @@ export function AuthProvider({ children }) {
   const login = async ({ email, password }) => {
     // Tu backend espera { email, contrasena }
     const data = await api.post('/auth/login', { email, contrasena: password });
-    // Respuesta esperada: { token, usuario }
-    const { token, usuario } = data || {};
+    // Respuesta esperada: { token, usuario, club? }
+    const { token, usuario, club } = data || {};
     if (!token || !usuario) throw new Error('Respuesta de login inválida');
 
+    // Enriquecemos el usuario con info del club si aplica
+    const userData = {
+      ...usuario,
+      ...(club ? { clubId: club.club_id, clubNombre: club.nombre } : {}),
+    };
+
     await storage.setItem(tokenKey, token);
-    await storage.setItem(userKey,  JSON.stringify(usuario));
-    setUser(usuario);
-    return usuario;
+    await storage.setItem(userKey, JSON.stringify(userData));
+    setUser(userData);
+    return userData;
   };
 
   const register = async (params) => {

--- a/meClub/src/lib/api.js
+++ b/meClub/src/lib/api.js
@@ -46,6 +46,9 @@ export const authApi = {
 };
 
 export async function getClubSummary({ clubId }) {
+  if (clubId === undefined) {
+    return { courtsAvailable: 0, reservasHoy: 0, reservasSemana: 0, economiaMes: 0 };
+  }
   try {
     const { data } = await api.get(`/clubes/${clubId}/resumen`);
     if (!data) {


### PR DESCRIPTION
## Summary
- Return associated club id and name on login when the user role is club
- Persist clubId and clubNombre in AuthProvider after login
- Prevent club summary fetch when clubId is undefined

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm test --prefix backend` *(fails: Missing script: "test")*
- `npm test --prefix meClub` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ba5a9728cc832f8a3a337d901a9970