### PR TITLE
fix: avoid auth header during login

### DIFF
--- a/meClub/src/features/auth/useAuth.js
+++ b/meClub/src/features/auth/useAuth.js
@@ -56,7 +56,7 @@ export function AuthProvider({ children }) {
 
   const login = async ({ email, password }) => {
     // Tu backend espera { email, contrasena }
-    const data = await api.post('/auth/login', { email, contrasena: password });
+    const data = await api.post('/auth/login', { email, contrasena: password }, { auth: false });
     // Respuesta esperada: { token, usuario }
     const { token, usuario } = data || {};
     if (!token || !usuario) throw new Error('Respuesta de login inválida');

--- a/meClub/src/lib/api.js
+++ b/meClub/src/lib/api.js
@@ -11,13 +11,13 @@ async function getToken() {
   return AsyncStorage.getItem(tokenKey);
 }
 
-async function request(path, { method = 'GET', body, headers } = {}) {
-  const token = await getToken();
+async function request(path, { method = 'GET', body, headers, auth = true } = {}) {
+  const token = auth ? await getToken() : null;
   const res = await fetch(`${BASE}${path}`, {
     method,
     headers: {
       'Content-Type': 'application/json',
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(auth && token ? { Authorization: `Bearer ${token}` } : {}),
       ...(headers || {}),
     },
     body: body ? JSON.stringify(body) : undefined,
@@ -34,10 +34,10 @@ async function request(path, { method = 'GET', body, headers } = {}) {
 }
 
 export const api = {
-  get: (p) => request(p),
-  post: (p, b) => request(p, { method: 'POST', body: b }),
-  put: (p, b) => request(p, { method: 'PUT', body: b }),
-  del: (p) => request(p, { method: 'DELETE' }),
+  get: (p, opts) => request(p, opts),
+  post: (p, b, opts) => request(p, { method: 'POST', body: b, ...(opts || {}) }),
+  put: (p, b, opts) => request(p, { method: 'PUT', body: b, ...(opts || {}) }),
+  del: (p, opts) => request(p, { method: 'DELETE', ...(opts || {}) }),
 };
 
 export const authApi = {


### PR DESCRIPTION
## Summary
- allow request() to skip Authorization header when auth disabled
- use new option in AuthProvider.login to prevent login failures with corrupt tokens

## Testing
- `npm test` *(fails: Missing script "test" )*
- Node script verifying headers built without auth: `auth false: { 'Content-Type': 'application/json' }`


------
https://chatgpt.com/codex/tasks/task_e_68ba5aaee49c832fa37a37311b8d24ab