### PR TITLE
feat: add placeholder dashboard screens

### DIFF
--- a/meClub/src/screens/DashboardShell.jsx
+++ b/meClub/src/screens/DashboardShell.jsx
@@ -4,9 +4,7 @@ import { useNavigation } from '@react-navigation/native';
 import { Ionicons, MaterialCommunityIcons, Feather } from '@expo/vector-icons';
 import { useAuth } from '../features/auth/useAuth';
 import { getClubSummary } from '../lib/api';
-import InicioScreen from './dashboard/InicioScreen';
-import ReservasScreen from './dashboard/ReservasScreen';
-import CanchasScreen from './dashboard/CanchasScreen';
+import { InicioScreen, ReservasScreen, CanchasScreen } from './dashboard';
 
 const NAV_BG = 'bg-[#0F172A]/80';
 

--- a/meClub/src/screens/dashboard/CanchasScreen.jsx
+++ b/meClub/src/screens/dashboard/CanchasScreen.jsx
@@ -3,9 +3,11 @@ import { View, Text } from 'react-native';
 
 export default function CanchasScreen() {
   return (
-    <View className="py-6">
-      <Text className="text-white text-[36px] font-extrabold tracking-tight">Mis Canchas</Text>
-      <Text className="text-white/60 mt-1">Próximamente</Text>
+    <View className="flex-1">
+      <View className="py-6">
+        <Text className="text-white text-[36px] font-extrabold tracking-tight">Mis Canchas</Text>
+        <Text className="text-white/60 mt-1">Próximamente</Text>
+      </View>
     </View>
   );
 }

--- a/meClub/src/screens/dashboard/ReservasScreen.jsx
+++ b/meClub/src/screens/dashboard/ReservasScreen.jsx
@@ -3,9 +3,11 @@ import { View, Text } from 'react-native';
 
 export default function ReservasScreen() {
   return (
-    <View className="py-6">
-      <Text className="text-white text-[36px] font-extrabold tracking-tight">Reservas</Text>
-      <Text className="text-white/60 mt-1">Próximamente</Text>
+    <View className="flex-1">
+      <View className="py-6">
+        <Text className="text-white text-[36px] font-extrabold tracking-tight">Reservas</Text>
+        <Text className="text-white/60 mt-1">Próximamente</Text>
+      </View>
     </View>
   );
 }

--- a/meClub/src/screens/dashboard/index.js
+++ b/meClub/src/screens/dashboard/index.js
@@ -1,0 +1,3 @@
+export { default as InicioScreen } from './InicioScreen';
+export { default as CanchasScreen } from './CanchasScreen';
+export { default as ReservasScreen } from './ReservasScreen';


### PR DESCRIPTION
## Summary
- add placeholder layout for Canchas and Reservas dashboard screens
- re-export dashboard screens via index file for simplified imports
- update DashboardShell imports to use centralized exports

## Testing
- `npm test` (fails: Missing script "test")
- `npm test` in frontend package (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_68ba79b4d794832fbbeea963a1ec1ea1