### PR TITLE
Codex- 0.1.5925.0259

### DIFF
--- a/meClub/src/screens/DashboardShell.jsx
+++ b/meClub/src/screens/DashboardShell.jsx
@@ -84,25 +84,8 @@ export default function DashboardShell() {
     { key: 'soporte', label: 'Soporte', icon: <Ionicons name="help-circle-outline" size={18} color="#9FB3C8" /> },
   ];
 
-  const routeMap = {
-    inicio: 'Dashboard',
-    buzon: 'Dashboard',
-    'mis-canchas': 'Dashboard',
-    reservas: 'Dashboard',
-    horarios: 'Dashboard',
-    tarifas: 'Dashboard',
-    grabaciones: 'Dashboard',
-    eventos: 'Dashboard',
-    'me-equipo': 'Dashboard',
-    ranking: 'Dashboard',
-    conciliar: 'Dashboard',
-    ajustes: 'Dashboard',
-    soporte: 'Dashboard',
-  };
-
   const go = (key) => {
     setActiveKey(key);
-    navigation.navigate(routeMap[key] || 'Dashboard');
   };
 
   const today = useMemo(() => {


### PR DESCRIPTION
## Summary
- remove route-based navigation from DashboardShell.go, relying solely on activeKey for screen changes

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68ba7b1d9bc0832fbde120148944cf5d