### PR TITLE
Codex- 0.1.5925.0305

### DIFF
--- a/meClub/src/screens/DashboardShell.jsx
+++ b/meClub/src/screens/DashboardShell.jsx
@@ -107,6 +107,7 @@ export default function DashboardShell() {
     'mis-canchas': CanchasScreen,
   };
   const ScreenComponent = screenMap[activeKey] || (() => null);
+  const screenProps = { summary, firstName, today };
 
   return (
     <View className="flex-1 bg-[#0A0F1D]">
@@ -166,7 +167,7 @@ export default function DashboardShell() {
 
         {/* MAIN */}
         <ScrollView className="flex-1 px-6" contentContainerStyle={{ paddingBottom: 40 }} showsVerticalScrollIndicator={false}>
-          <ScreenComponent summary={summary} firstName={firstName} today={today} />
+          <ScreenComponent {...screenProps} />
         </ScrollView>
       </View>
     </View>

--- a/meClub/src/screens/dashboard/InicioScreen.jsx
+++ b/meClub/src/screens/dashboard/InicioScreen.jsx
@@ -5,7 +5,7 @@ import { Ionicons } from '@expo/vector-icons';
 const PANEL_BG = 'bg-[#0F172A]/90';
 const cardCls = `${PANEL_BG} rounded-2xl p-5 shadow-[0_2px_8px_rgba(148,163,184,0.12),0_2px_8px_rgba(255,255,255,0.06)]`;
 
-export default function InicioScreen({ summary, firstName, today }) {
+export default function InicioScreen({ summary = {}, firstName, today }) {
   return (
     <>
       <View className="py-6">
@@ -19,7 +19,7 @@ export default function InicioScreen({ summary, firstName, today }) {
           <View className={`flex-1 ${cardCls}`}>
             <Text className="text-teal-300 font-semibold tracking-widest text-[13px]">MIS CANCHAS</Text>
             <Text className="text-white text-[32px] mt-2 font-bold">
-              {summary.courtsAvailable} disponibles
+              {summary.courtsAvailable ?? 0} disponibles
             </Text>
             <Pressable className="self-start mt-4 rounded-xl px-4 py-2 border border-teal-300/30 bg-teal-400/20 hover:bg-teal-400/30">
               <Text className="text-teal-200 font-medium">VER CANCHAS</Text>
@@ -38,9 +38,9 @@ export default function InicioScreen({ summary, firstName, today }) {
           <View className={`flex-1 ${cardCls}`}>
             <Text className="text-sky-300 font-semibold tracking-widest text-[13px]">RESERVAS</Text>
             <Text className="text-white text-[32px] mt-2 font-bold">
-              {summary.reservasHoy} hoy
+              {summary.reservasHoy ?? 0} hoy
             </Text>
-            <Text className="text-white/60 mt-1">+{summary.reservasSemana} esta semana</Text>
+            <Text className="text-white/60 mt-1">+{summary.reservasSemana ?? 0} esta semana</Text>
             <Pressable className="self-start mt-4 rounded-xl px-4 py-2 border border-sky-300/30 bg-sky-400/15 hover:bg-sky-400/25">
               <Text className="text-sky-200 font-medium">VER RESERVAS</Text>
             </Pressable>
@@ -49,7 +49,7 @@ export default function InicioScreen({ summary, firstName, today }) {
           <View className={`flex-1 ${cardCls}`}>
             <Text className="text-emerald-300 font-semibold tracking-widest text-[13px]">ECONOMÍA</Text>
             <Text className="text-white text-[32px] mt-2 font-bold">
-              {`$${Number(summary.economiaMes || 0).toLocaleString('es-AR')} este mes`}
+              {`$${Number(summary.economiaMes ?? 0).toLocaleString('es-AR')} este mes`}
             </Text>
             <View className="mt-4 h-24 rounded-xl bg-white/5" />
           </View>


### PR DESCRIPTION
## Summary
- pass summary, firstName and today to dynamic dashboard screens
- consume summary props in InicioScreen with safe defaults

## Testing
- `npm test --prefix meClub` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ba7c7ad92c832fac4556a4a190d755