### PR TITLE
Codex- 0.1.5925.0311

### DIFF
--- a/MANUAL_TESTS.md
+++ b/MANUAL_TESTS.md
@@ -1,0 +1,14 @@
+# Manual Tests
+
+## Sidebar initial state
+
+1. Start the web client:
+   ```bash
+   npm run web --prefix meClub
+   ```
+2. Log in as a club user so that the `Dashboard` screen renders.
+3. Confirm the following:
+   - In the sidebar, the **Inicio** item is highlighted on first load.
+   - The main content shows the **Inicio** screen summary.
+4. Click another sidebar item such as **Reservas** and verify the highlight moves accordingly.
+5. Reload the page or navigate away and back to the dashboard. The **Inicio** item should again be highlighted by default.

--- a/meClub/src/screens/DashboardShell.jsx
+++ b/meClub/src/screens/DashboardShell.jsx
@@ -46,6 +46,13 @@ export default function DashboardShell() {
   });
 
   useEffect(() => {
+    const unsubscribe = navigation.addListener('focus', () => {
+      setActiveKey('inicio');
+    });
+    return unsubscribe;
+  }, [navigation]);
+
+  useEffect(() => {
     let alive = true;
     (async () => {
       try {


### PR DESCRIPTION
## Summary
- reset sidebar selection to "Inicio" when Dashboard screen gains focus
- document manual testing steps for verifying sidebar and content initial state

## Testing
- `npm test` (fails: Missing script "test")
- `npm test --prefix meClub` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68ba7e1b953c832fbd984d56d2613ec1