### PR TITLE
refactor: unify card shadow class

### DIFF
--- a/meClub/src/screens/dashboard/InicioScreen.jsx
+++ b/meClub/src/screens/dashboard/InicioScreen.jsx
@@ -3,7 +3,7 @@ import { View, Text, Pressable } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 
 const PANEL_BG = 'bg-[#0F172A]/90';
-const cardCls = `${PANEL_BG} rounded-2xl p-5 shadow-[0_2px_8px_rgba(148,163,184,0.12),0_2px_8px_rgba(255,255,255,0.06)]`;
+const cardCls = `${PANEL_BG} rounded-2xl p-5 shadow-card`;
 
 export default function InicioScreen({ summary = {}, firstName, today }) {
   return (

--- a/meClub/tailwind.config.js
+++ b/meClub/tailwind.config.js
@@ -26,7 +26,7 @@ module.exports = {
       },
       boxShadow: {
         soft: '0 8px 24px rgba(0,0,0,0.25)',
-        "card": "0 10px 30px rgba(0,0,0,0.25)",
+        card: '0 2px 8px rgba(148,163,184,0.12), 0 2px 8px rgba(255,255,255,0.06)',
       },
       fontFamily: {
         sans: ["Inter", "system-ui", "Segoe UI", "Roboto", "Helvetica", "Arial", "sans-serif"],


### PR DESCRIPTION
## Summary
- replace inline dashboard card shadow with reusable `shadow-card`
- update Tailwind config with shared `card` shadow values

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ba88a34efc832fb52d74c9a8d7dbb7