### PR TITLE
Codex- 0.1.5925.0424

### DIFF
--- a/meClub/src/components/Card.jsx
+++ b/meClub/src/components/Card.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { View } from 'react-native';
+
+/**
+ * Reusable container that applies the default dashboard card styles.
+ *
+ * Adds background, padding, rounded corners and shadow. Extra Tailwind
+ * classes can be provided via `className` to further customize the card.
+ */
+export default function Card({ className = '', children, ...rest }) {
+  return (
+    <View
+      className={`bg-[#0F172A]/90 rounded-2xl p-5 shadow-card ${className}`}
+      {...rest}
+    >
+      {children}
+    </View>
+  );
+}

--- a/meClub/src/screens/dashboard/InicioScreen.jsx
+++ b/meClub/src/screens/dashboard/InicioScreen.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import { View, Text, Pressable } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-
-const PANEL_BG = 'bg-[#0F172A]/90';
-const cardCls = `${PANEL_BG} rounded-2xl p-5 shadow-card`;
+import Card from '../../components/Card';
 
 export default function InicioScreen({ summary = {}, firstName, today, go }) {
   return (
@@ -16,7 +14,7 @@ export default function InicioScreen({ summary = {}, firstName, today, go }) {
       <View className="gap-6">
         {/* fila 1 */}
         <View className="flex-row gap-6">
-          <View className={`flex-1 ${cardCls}`}>
+          <Card className="flex-1">
             <Text className="text-teal-300 font-semibold tracking-widest text-[13px]">MIS CANCHAS</Text>
             <Text className="text-white text-[32px] mt-2 font-bold">
               {summary.courtsAvailable ?? 0} disponibles
@@ -27,18 +25,18 @@ export default function InicioScreen({ summary = {}, firstName, today, go }) {
             >
               <Text className="text-teal-200 font-medium">VER CANCHAS</Text>
             </Pressable>
-          </View>
+          </Card>
 
-          <View className={`flex-1 ${cardCls}`}>
+          <Card className="flex-1">
             <Text className="text-amber-300 font-semibold tracking-widest text-[13px]">PRÓXIMO EVENTO</Text>
             <Text className="text-white text-[28px] mt-2 font-semibold">Torneo de Primavera</Text>
             <Text className="text-white/60 mt-2">martes, 30 de abril de 2024</Text>
-          </View>
+          </Card>
         </View>
 
         {/* fila 2 */}
         <View className="flex-row gap-6">
-          <View className={`flex-1 ${cardCls}`}>
+          <Card className="flex-1">
             <Text className="text-sky-300 font-semibold tracking-widest text-[13px]">RESERVAS</Text>
             <Text className="text-white text-[32px] mt-2 font-bold">
               {summary.reservasHoy ?? 0} hoy
@@ -50,34 +48,34 @@ export default function InicioScreen({ summary = {}, firstName, today, go }) {
             >
               <Text className="text-sky-200 font-medium">VER RESERVAS</Text>
             </Pressable>
-          </View>
+          </Card>
 
-          <View className={`flex-1 ${cardCls}`}>
+          <Card className="flex-1">
             <Text className="text-emerald-300 font-semibold tracking-widest text-[13px]">ECONOMÍA</Text>
             <Text className="text-white text-[32px] mt-2 font-bold">
               {`$${Number(summary.economiaMes ?? 0).toLocaleString('es-AR')} este mes`}
             </Text>
             <View className="mt-4 h-24 rounded-xl bg-white/5" />
-          </View>
+          </Card>
         </View>
 
         {/* fila 3 */}
         <View className="flex-row gap-6">
-          <View className={`flex-1 ${cardCls}`}>
+          <Card className="flex-1">
             <Text className="text-teal-300 font-semibold tracking-widest text-[13px]">EVENTOS</Text>
             <View className="mt-3 flex-row items-center justify-between">
               <Text className="text-white text-[24px] font-semibold">meEquipo</Text>
               <Ionicons name="chevron-forward" size={20} color="#9FB3C8" />
             </View>
-          </View>
+          </Card>
 
-          <View className={`flex-1 ${cardCls}`}>
+          <Card className="flex-1">
             <Text className="text-teal-300 font-semibold tracking-widest text-[13px]">EVENTOS</Text>
             <View className="mt-3 flex-row items-center justify-between">
               <Text className="text-white text-[24px] font-semibold">Ranking</Text>
               <Ionicons name="chevron-forward" size={20} color="#9FB3C8" />
             </View>
-          </View>
+          </Card>
         </View>
       </View>
     </>


### PR DESCRIPTION
## Summary
- create reusable `Card` component with shared dashboard styling
- refactor `InicioScreen` to render cards via `<Card>` instead of `cardCls`
- document `Card` for future reuse

## Testing
- `cd meClub && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ba8cfa735c832fa1085b3d922bc974