### PR TITLE
feat: provide custom navigation theme

### DIFF
--- a/meClub/src/navigation/RootNavigator.jsx
+++ b/meClub/src/navigation/RootNavigator.jsx
@@ -7,6 +7,7 @@ import LoginScreen from '../screens/LoginScreen';
 import DashboardShell from '../screens/DashboardShell';
 import ProtectedRoute from './ProtectedRoute';
 import { useAuth } from '../features/auth/useAuth';
+import { theme } from '../theme';
 
 const Stack = createNativeStackNavigator();
 
@@ -22,7 +23,7 @@ export default function RootNavigator() {
   }
 
   return (
-    <NavigationContainer>
+    <NavigationContainer theme={theme}>
       <Stack.Navigator screenOptions={{ headerShown: false, animation: 'fade' }}>
         <Stack.Screen name="Landing" component={LandingScreen} />
         <Stack.Screen name="Login" component={LoginScreen} />

--- a/meClub/src/screens/DashboardShell.jsx
+++ b/meClub/src/screens/DashboardShell.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { View, Text, Pressable, ScrollView, Image } from 'react-native';
 import { useNavigation, useTheme } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
+import { colors as mcColors } from '../theme/tokens';
 import { useAuth } from '../features/auth/useAuth';
 import { getClubSummary } from '../lib/api';
 import { InicioScreen, ReservasScreen, CanchasScreen } from './dashboard';
@@ -10,6 +11,7 @@ const NAV_BG = 'bg-[#0F172A]/80';
 
 function SidebarItem({ iconName, label, active, onPress }) {
   const theme = useTheme();
+  const warnColor = theme?.colors?.mc?.warn ?? mcColors.warn;
   return (
     <Pressable
       onPress={onPress}
@@ -25,7 +27,7 @@ function SidebarItem({ iconName, label, active, onPress }) {
           <Ionicons
             name={iconName}
             size={18}
-            color={active ? theme.colors.mc.warn : '#9FB3C8'}
+            color={active ? warnColor : '#9FB3C8'}
           />
         )}
         <Text

--- a/meClub/src/theme/index.js
+++ b/meClub/src/theme/index.js
@@ -1,0 +1,12 @@
+import { DefaultTheme } from '@react-navigation/native';
+import { colors as mc } from './tokens';
+
+export const theme = {
+  ...DefaultTheme,
+  colors: {
+    ...DefaultTheme.colors,
+    mc,
+  },
+};
+
+export default theme;


### PR DESCRIPTION
## Summary
- extend navigation theme with mc color tokens
- wire theme into RootNavigator
- safeguard dashboard icon color with theme

## Testing
- `npm test` *(fails: Missing script "test"))*

------
https://chatgpt.com/codex/tasks/task_e_68ba934c47e8832f80c4d65ddd2d6e6a