### PR TITLE
Genera JWT en registro y añade tests

### DIFF
--- a/backend/controllers/auth.controller.js
+++ b/backend/controllers/auth.controller.js
@@ -43,11 +43,25 @@ exports.register = async (req, res) => {
       });
     }
 
+    const token = jwt.sign(
+      {
+        usuario_id: nuevoUsuario.usuario_id,
+        email: nuevoUsuario.email,
+        rol: nuevoUsuario.rol,
+      },
+      process.env.JWT_SECRET,
+      { expiresIn: '24h' }
+    );
+
+    const clubInfo = clubCreado
+      ? { club_id: clubCreado.club_id, nombre: clubCreado.nombre }
+      : null;
+
     res.status(201).json({
       mensaje: 'Usuario registrado correctamente',
       token,
       usuario: nuevoUsuario,
-      club: clubCreado,
+      club: clubInfo,
     });
   } catch (error) {
     console.error('Error en registro:', error);

--- a/backend/tests/register.test.js
+++ b/backend/tests/register.test.js
@@ -4,8 +4,11 @@ const UsuariosModel = require('../models/usuarios.model');
 const ClubesModel = require('../models/clubes.model');
 const bcrypt = require('bcryptjs');
 
+process.env.JWT_SECRET = 'secret';
+bcrypt.hash = async () => 'hash';
+
 (async () => {
-  // Preparar mocks
+  // Caso 1: registro de deportista (sin club)
   UsuariosModel.buscarPorEmail = async () => [];
   UsuariosModel.crearUsuario = async (u) => ({
     usuario_id: 1,
@@ -15,9 +18,6 @@ const bcrypt = require('bcryptjs');
     rol: u.rol,
   });
   ClubesModel.crearClub = async () => null;
-  bcrypt.hash = async () => 'hash';
-
-  process.env.JWT_SECRET = 'secret';
 
   let statusCode = 0;
   let jsonBody = null;
@@ -34,5 +34,36 @@ const bcrypt = require('bcryptjs');
   assert.strictEqual(statusCode, 201);
   assert.ok(jsonBody.token, 'token should be returned');
   assert.ok(jsonBody.usuario, 'usuario should be returned');
-  console.log('register returned { token, usuario }');
+  assert.strictEqual(jsonBody.club, null, 'club should be null for deportista');
+  console.log('register returned { token, usuario, club:null }');
+
+  // Caso 2: registro de club
+  UsuariosModel.buscarPorEmail = async () => [];
+  UsuariosModel.crearUsuario = async (u) => ({
+    usuario_id: 2,
+    nombre: u.nombre,
+    apellido: u.apellido,
+    email: u.email,
+    rol: u.rol,
+  });
+  ClubesModel.crearClub = async () => ({ club_id: 10, nombre: 'Club Test' });
+
+  statusCode = 0;
+  jsonBody = null;
+  const reqClub = {
+    body: {
+      nombre: 'Club',
+      apellido: 'Owner',
+      email: 'club@example.com',
+      contrasena: '1234',
+      rol: 'club',
+    },
+  };
+  await register(reqClub, res);
+
+  assert.strictEqual(statusCode, 201);
+  assert.ok(jsonBody.token, 'token should be returned');
+  assert.ok(jsonBody.usuario, 'usuario should be returned');
+  assert.deepStrictEqual(jsonBody.club, { club_id: 10, nombre: 'Club Test' });
+  console.log('register returned { token, usuario, club } for club role');
 })();


### PR DESCRIPTION
## Summary
- Genera y devuelve JWT tras crear usuario y club en endpoint register
- Incluye datos del club creado en la respuesta del registro
- Agrega pruebas para verificar que register responde con token, usuario y club

## Testing
- `node backend/tests/register.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba941a1be4832f80a742a2b5cf2d33