### PR TITLE
Codex- 0.1.5925.0449

### DIFF
--- a/backend/models/clubes.model.js
+++ b/backend/models/clubes.model.js
@@ -63,12 +63,16 @@ const ClubesModel = {
       [club_id]
     );
 
+    const reservasSemanaQuery = `
+      SELECT COUNT(*) AS total
+      FROM reservas r
+      JOIN canchas c ON c.cancha_id = r.cancha_id
+      WHERE c.club_id = ?
+        AND YEARWEEK(r.fecha, 1) = YEARWEEK(CURDATE(), 1)
+    `;
+
     const [[{ total: reservasSemana = 0 } = {}]] = await db.query(
-      `SELECT COUNT(*) AS total
-       FROM reservas r
-       JOIN canchas c ON c.cancha_id = r.cancha_id
-       WHERE c.club_id = ?
-         AND YEARWEEK(r.fecha, 1) = YEARWEEK(CURDATE(), 1)`,
+      reservasSemanaQuery,
       [club_id]
     );
 

--- a/backend/test/obtenerResumen.test.js
+++ b/backend/test/obtenerResumen.test.js
@@ -1,0 +1,25 @@
+const assert = require('assert');
+const path = require('path');
+
+// Mock database module before requiring the model
+const dbPath = path.resolve(__dirname, '../config/db');
+require.cache[require.resolve(dbPath)] = {
+  exports: {
+    query: async (sql) => {
+      if (sql.includes('FROM canchas')) return [[{ total: 2 }]];
+      if (sql.includes('r.fecha = CURDATE()')) return [[{ total: 3 }]];
+      if (sql.includes('YEARWEEK')) return [[{ total: 4 }]];
+      if (sql.includes('COALESCE(SUM')) return [[{ total: 100 }]];
+      return [[{ total: 0 }]];
+    },
+  },
+};
+
+const ClubesModel = require('../models/clubes.model');
+
+(async () => {
+  const resumen = await ClubesModel.obtenerResumen(1);
+  assert.strictEqual(resumen.reservasSemana, 4);
+  console.log('obtenerResumen:', resumen);
+})();
+


### PR DESCRIPTION
## Summary
- ensure weekly reservations query is built as a single template string
- add unit test to validate resumen values including weekly reservations

## Testing
- `node backend/test/obtenerResumen.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68ba9504845c832f80be012142f9e97d