### PR TITLE
Codex- 0.1.5925.0526

### DIFF
--- a/backend/controllers/auth.controller.js
+++ b/backend/controllers/auth.controller.js
@@ -144,8 +144,8 @@ exports.forgot = async (req, res) => {
     const frontBase = process.env.FRONT_BASE_URL || 'http://localhost:19006';
     const link = `${frontBase}/reset?token=${rawToken}`;
 
-    // En producción = enviar email. En dev devuelve el token/link.
-    if (process.env.NODE_ENV !== 'production') {
+    // En modo desarrollo se devuelve el token/link para pruebas.
+    if (process.env.NODE_ENV === 'development') {
       console.log('[meClub] Link de reseteo:', link);
       return res.json({ mensaje: 'Instrucciones enviadas', token: rawToken, link });
     }


### PR DESCRIPTION
## Summary
- Return password reset token only when `NODE_ENV` is `development`
- Send confirmation message without token in other environments

## Testing
- `node backend/test/obtenerResumen.test.js`
- `node backend/tests/register.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba9e3fdef0832f8a2f90b6981a0b91