### PR TITLE
Codex- 0.1.5925.0534

### DIFF
--- a/meClub/src/screens/DashboardShell.jsx
+++ b/meClub/src/screens/DashboardShell.jsx
@@ -48,10 +48,10 @@ export default function DashboardShell() {
   const { user, logout } = useAuth();
   const [activeKey, setActiveKey] = useState('inicio');
   const [summary, setSummary] = useState({
-    courtsAvailable: 3,
-    reservasHoy: 8,
-    reservasSemana: 24,
-    economiaMes: 14520,
+    courtsAvailable: 0,
+    reservasHoy: 0,
+    reservasSemana: 0,
+    economiaMes: 0,
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- initialize DashboardShell summary state with zero values to remove sample data
- confirm club summary fetched via `getClubSummary` to populate data

## Testing
- `npm test --prefix meClub` *(fails: Missing script: "test")*
- `npm test --prefix backend` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68baa00140dc832f9140f009fba86f5f