### PR TITLE
refactor: centralize storage utilities

### DIFF
--- a/meClub/src/lib/api.js
+++ b/meClub/src/lib/api.js
@@ -1,18 +1,9 @@
-import { Platform } from 'react-native';
-import * as SecureStore from 'expo-secure-store';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import { tokenKey, getItem } from './storage';
 
 const BASE = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3006/api';
 
-const tokenKey = 'mc_token';
-async function getToken() {
-  try { const t = await SecureStore.getItemAsync(tokenKey); if (t) return t; } catch {}
-  if (Platform.OS === 'web') return localStorage.getItem(tokenKey);
-  return AsyncStorage.getItem(tokenKey);
-}
-
 async function request(path, { method = 'GET', body, headers, auth = true } = {}) {
-  const token = auth ? await getToken() : null;
+  const token = auth ? await getItem(tokenKey) : null;
   const res = await fetch(`${BASE}${path}`, {
     method,
     headers: {

--- a/meClub/src/lib/storage.js
+++ b/meClub/src/lib/storage.js
@@ -1,0 +1,26 @@
+import { Platform } from 'react-native';
+import * as SecureStore from 'expo-secure-store';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export const tokenKey = 'mc_token';
+
+export async function getItem(k) {
+  try { const v = await SecureStore.getItemAsync(k); if (v != null) return v; } catch {}
+  if (Platform.OS === 'web' && typeof localStorage !== 'undefined') {
+    const v = localStorage.getItem(k);
+    if (v != null) return v;
+  }
+  return AsyncStorage.getItem(k);
+}
+
+export async function setItem(k, v) {
+  try { await SecureStore.setItemAsync(k, v); } catch {}
+  if (Platform.OS === 'web' && typeof localStorage !== 'undefined') localStorage.setItem(k, v);
+  await AsyncStorage.setItem(k, v);
+}
+
+export async function delItem(k) {
+  try { await SecureStore.deleteItemAsync(k); } catch {}
+  if (Platform.OS === 'web' && typeof localStorage !== 'undefined') localStorage.removeItem(k);
+  await AsyncStorage.removeItem(k);
+}


### PR DESCRIPTION
## Summary
- add shared storage module for hybrid get/set/del operations
- refactor auth and API utilities to use shared storage and common token key

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68baa245a8f8832fa491f8928c58fbb4