### PR TITLE
Negan- 0.1.6925.1924

### DIFF
--- a/meClub/src/navigation/RootNavigator.jsx
+++ b/meClub/src/navigation/RootNavigator.jsx
@@ -18,7 +18,7 @@ const linking = {
 };
 
 export default function RootNavigator() {
-  const { ready } = useAuth();
+  const { ready, isLogged, isClub } = useAuth();
 
   if (!ready) {
     return (
@@ -28,9 +28,15 @@ export default function RootNavigator() {
     );
   }
 
+  const initialRouteName = isLogged && isClub ? 'Dashboard' : 'Landing';
+
   return (
     <NavigationContainer theme={theme} linking={linking}>
-      <Stack.Navigator screenOptions={{ headerShown: false, animation: 'fade' }}>
+      <Stack.Navigator
+        key={isLogged ? 'auth' : 'guest'}
+        initialRouteName={initialRouteName}
+        screenOptions={{ headerShown: false, animation: 'fade' }}
+      >
         <Stack.Screen name="Landing" component={LandingScreen} />
         <Stack.Screen name="Login" component={LoginScreen} />
         <Stack.Screen name="Dashboard">


### PR DESCRIPTION
## Summary
- Derive auth flags from `useAuth` in `RootNavigator`
- Reset navigation stack on auth state changes with keyed `Stack.Navigator`
- Set initial route to Dashboard for logged club users or Landing otherwise

## Testing
- `npm test --prefix meClub` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bcb2d6b668832fbc0d03b1d8385232