### PR TITLE
Negan-  0.1.6925.1932

### DIFF
--- a/meClub/src/features/auth/useAuth.js
+++ b/meClub/src/features/auth/useAuth.js
@@ -3,6 +3,7 @@ import { createContext, useContext, useMemo, useState, useEffect } from 'react';
 import { Platform } from 'react-native';
 import { api } from '../../lib/api';
 import { tokenKey, getItem, setItem, delItem } from '../../lib/storage';
+import { navigationRef } from '../../navigation/navigationRef';
 
 const AuthCtx = createContext(null);
 export const useAuth = () => {
@@ -66,9 +67,16 @@ export function AuthProvider({ children }) {
     await delItem(tokenKey);
     await delItem(userKey);
     setUser(null);
-    // Redirección robusta en Web: evita que el stack quede en /dashboard
-    if (Platform.OS === 'web') {
-      try { window.location.assign('/login'); } catch {}
+    try {
+      if (navigationRef.isReady()) {
+        navigationRef.reset({ index: 0, routes: [{ name: 'Login' }] });
+      } else if (Platform.OS === 'web') {
+        window.location.assign('/login');
+      }
+    } catch {
+      if (Platform.OS === 'web') {
+        try { window.location.assign('/login'); } catch {}
+      }
     }
   };
   const isClub = !!user && String(user.rol ?? user.role ?? '').toLowerCase().startsWith('club');

--- a/meClub/src/navigation/RootNavigator.jsx
+++ b/meClub/src/navigation/RootNavigator.jsx
@@ -9,6 +9,7 @@ import DashboardShell from '../screens/DashboardShell';
 import ProtectedRoute from './ProtectedRoute';
 import { useAuth } from '../features/auth/useAuth';
 import { theme } from '../theme';
+import { navigationRef } from './navigationRef';
 
 const Stack = createNativeStackNavigator();
 
@@ -31,7 +32,7 @@ export default function RootNavigator() {
   const initialRouteName = isLogged && isClub ? 'Dashboard' : 'Landing';
 
   return (
-    <NavigationContainer theme={theme} linking={linking}>
+    <NavigationContainer ref={navigationRef} theme={theme} linking={linking}>
       <Stack.Navigator
         key={isLogged ? 'auth' : 'guest'}
         initialRouteName={initialRouteName}

--- a/meClub/src/navigation/navigationRef.js
+++ b/meClub/src/navigation/navigationRef.js
@@ -1,0 +1,3 @@
+import { createNavigationContainerRef } from '@react-navigation/native';
+
+export const navigationRef = createNavigationContainerRef();

--- a/meClub/src/screens/DashboardShell.jsx
+++ b/meClub/src/screens/DashboardShell.jsx
@@ -75,13 +75,7 @@ export default function DashboardShell() {
   }, [user?.clubId, user?.club?.id]);
 
   const handleLogout = async () => {
-    try { await logout(); } finally {
-      if (typeof window !== 'undefined') {
-        window.location.assign('/');
-      } else {
-        try { navigation.reset({ index: 0, routes: [{ name: 'Login' }] }); } catch {}
-      }
-    }
+    await logout();
   };
 
   const items = [


### PR DESCRIPTION
## Summary
- create and export a global navigation ref
- use navigation ref to reset to login on logout with web fallback
- simplify dashboard logout handler

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bcb4fa13ac832f887d36da209fd671