### PR TITLE
fix: add expo-linking dependency

### DIFF
--- a/meClub/package.json
+++ b/meClub/package.json
@@ -24,6 +24,7 @@
     "expo-constants": "^17.1.7",
     "expo-font": "^13.3.2",
     "expo-linear-gradient": "^14.1.5",
+    "expo-linking": "~7.1.7",
     "expo-secure-store": "~13.0.2",
     "expo-status-bar": "~2.2.3",
     "history": "^5.3.0",


### PR DESCRIPTION
## Summary
- add expo-linking dependency so Metro can resolve it

## Testing
- `npx expo install expo-linking` *(fails: TypeError: fetch failed)*
- `npm install expo-linking@~7.1.7`
- `timeout 10s npm run dev` *(fails: TypeError: fetch failed, but no "Unable to resolve expo-linking" message)*

------
https://chatgpt.com/codex/tasks/task_e_68bcbcca2e34832fa3a1b1635b8f5c1f