### PR TITLE
Negan- 0.2.6925.2129

### DIFF
--- a/meClub/src/lib/api.js
+++ b/meClub/src/lib/api.js
@@ -4,15 +4,20 @@ const BASE = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3006/api';
 
 async function request(path, { method = 'GET', body, headers, auth = true } = {}) {
   const token = auth ? await getItem(tokenKey) : null;
-  const res = await fetch(`${BASE}${path}`, {
-    method,
-    headers: {
-      'Content-Type': 'application/json',
-      ...(auth && token ? { Authorization: `Bearer ${token}` } : {}),
-      ...(headers || {}),
-    },
-    body: body ? JSON.stringify(body) : undefined,
-  });
+  let res;
+  try {
+    res = await fetch(`${BASE}${path}`, {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(auth && token ? { Authorization: `Bearer ${token}` } : {}),
+        ...(headers || {}),
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+  } catch {
+    throw new Error('Network unavailable');
+  }
   const data = await res.json().catch(() => ({}));
   if (!res.ok) {
     const msg = data?.mensaje || data?.error || `HTTP ${res.status}`;
@@ -55,7 +60,6 @@ export async function getClubSummary({ clubId }) {
     };
   } catch (err) {
     console.warn('getClubSummary error', err);
-    // Si el backend no responde devolvemos valores en cero
-    return { courtsAvailable: 0, reservasHoy: 0, reservasSemana: 0, economiaMes: 0 };
+    throw err;
   }
 }

--- a/meClub/src/screens/DashboardShell.jsx
+++ b/meClub/src/screens/DashboardShell.jsx
@@ -53,6 +53,7 @@ export default function DashboardShell() {
     reservasSemana: 0,
     economiaMes: 0,
   });
+  const [err, setErr] = useState('');
 
   useEffect(() => {
     const unsubscribe = navigation.addListener('focus', () => {
@@ -66,9 +67,12 @@ export default function DashboardShell() {
     (async () => {
       try {
         const data = await getClubSummary({ clubId: user?.clubId || user?.club?.id });
-        if (alive && data) setSummary(data);
-      } catch {
-        /* fallback */
+        if (alive && data) {
+          setSummary(data);
+          setErr('');
+        }
+      } catch (e) {
+        if (alive) setErr(e.message);
       }
     })();
     return () => { alive = false; };
@@ -181,6 +185,7 @@ export default function DashboardShell() {
           contentContainerStyle={{ paddingBottom: 40 }}
           showsVerticalScrollIndicator={false}
         >
+          {!!err && <Text className="text-red-400 text-center my-2">{err}</Text>}
           <ScreenComponent {...screenProps} />
         </ScrollView>
       </View>


### PR DESCRIPTION
## Summary
- Wrap API fetch call in try/catch and surface a `Network unavailable` error when requests fail.
- Propagate errors from `getClubSummary` so they can be shown to the user.
- Display network error messages in the dashboard.

## Testing
- `npm test --prefix meClub` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bcd0d43724832f88f3f80a5c1f91be