### PR TITLE
Negan- 0.2.6925.2135

### DIFF
--- a/meClub/src/lib/storage.js
+++ b/meClub/src/lib/storage.js
@@ -4,23 +4,45 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 
 export const tokenKey = 'mc_token';
 
+// Prefer SecureStore on native platforms for sensitive data such as tokens.
+// AsyncStorage is only a fallback when SecureStore is unavailable (e.g. on
+// web or when SecureStore throws). This avoids keeping tokens in the less
+// secure AsyncStorage when we can store them in the device's encrypted key
+// chain instead.
 export async function getItem(k) {
-  try { const v = await SecureStore.getItemAsync(k); if (v != null) return v; } catch {}
-  if (Platform.OS === 'web' && typeof localStorage !== 'undefined') {
-    const v = localStorage.getItem(k);
-    if (v != null) return v;
+  if (Platform.OS !== 'web') {
+    try {
+      const v = await SecureStore.getItemAsync(k);
+      if (v != null) return v;
+    } catch {
+      // SecureStore failed, fall back to AsyncStorage
+    }
   }
   return AsyncStorage.getItem(k);
 }
 
 export async function setItem(k, v) {
-  try { await SecureStore.setItemAsync(k, v); } catch {}
-  if (Platform.OS === 'web' && typeof localStorage !== 'undefined') localStorage.setItem(k, v);
+  if (Platform.OS !== 'web') {
+    try {
+      await SecureStore.setItemAsync(k, v);
+      // Successful writes stop here so the token isn't duplicated in
+      // AsyncStorage, which is less secure.
+      return;
+    } catch {
+      // SecureStore failed, fall back to AsyncStorage
+    }
+  }
   await AsyncStorage.setItem(k, v);
 }
 
 export async function delItem(k) {
-  try { await SecureStore.deleteItemAsync(k); } catch {}
-  if (Platform.OS === 'web' && typeof localStorage !== 'undefined') localStorage.removeItem(k);
+  if (Platform.OS !== 'web') {
+    try {
+      await SecureStore.deleteItemAsync(k);
+      return;
+    } catch {
+      // SecureStore failed, fall back to AsyncStorage
+    }
+  }
   await AsyncStorage.removeItem(k);
 }


### PR DESCRIPTION
## Summary
- Prefer SecureStore for storing sensitive data
- Fall back to AsyncStorage only on web or when SecureStore fails
- Add explanatory comments about security rationale

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bcd1e341cc832fa5031adbcce25cdb