### PR TITLE
Negan- 0.2.7925.0007

### DIFF
--- a/meClub/src/features/auth/useAuth.js
+++ b/meClub/src/features/auth/useAuth.js
@@ -55,19 +55,10 @@ export function AuthProvider({ children }) {
     if (foto_logo) payload.foto_logo = foto_logo;
     if (nivel_id) payload.nivel_id = nivel_id;
     const data = await api.post('/auth/register', payload, { auth: false });
-    // Algunas versiones del backend pueden devolver `user` en lugar de `usuario`
-    const { token, usuario, user, club } = data || {};
-    const usr = usuario || user;
-    if (!token || !usr) throw new Error('Respuesta de registro inválida');
-    const userData = {
-      ...usr,
-      ...(club ? { clubId: club.club_id, clubNombre: club.nombre } : {}),
-    };
-
-    await setItem(tokenKey, token);
-    await setItem(userKey, JSON.stringify(userData));
-    setUser(userData);
-    return userData;
+    // Devolver solo el mensaje y asegurarse de cerrar cualquier sesión previa
+    const { mensaje } = data || {};
+    await logout();
+    return mensaje;
   };
 
 

--- a/meClub/src/screens/LoginScreen.jsx
+++ b/meClub/src/screens/LoginScreen.jsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { View, Text, TextInput, Pressable, ActivityIndicator, Platform, Keyboard } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useAuth } from '../features/auth/useAuth';
-import { api, authApi } from '../lib/api';
+import { authApi } from '../lib/api';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Controller, useForm } from 'react-hook-form';
@@ -40,13 +40,13 @@ const resetSchema = z.object({
 
 export default function LoginScreen() {
   const nav  = useNavigation();
-  const { login, register, user, isLogged } = useAuth();
+  const { login, register, isLogged } = useAuth();
 
   useEffect(() => {
     if (isLogged) {
       nav.reset({ index: 0, routes: [{ name: 'Dashboard' }] });
     }
-  }, [isLogged, nav, user]);
+  }, [isLogged, nav]);
 
   // 'login' | 'register' | 'forgot' | 'reset'
   const [mode, setMode] = useState('login');
@@ -125,7 +125,8 @@ export default function LoginScreen() {
     setBusy(true); setErr(''); setOk('');
     try {
       await register(data);
-      nav.reset({ index: 0, routes: [{ name: 'Dashboard' }] });
+      nav.reset({ index: 0, routes: [{ name: 'Login' }] });
+      setOk('Usuario creado, por favor inicia sesión');
     } catch (e) {
       setErr(e.message || 'No se pudo registrar');
     } finally { setBusy(false); }


### PR DESCRIPTION
## Summary
- stop saving session when registering and return only success message
- send users back to login with a notice after registration
- guard dashboard redirect to only trigger when session exists

## Testing
- `npm test` (fails: Missing script "test")
- `cd meClub && npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68bcf3f8e10c832f899dac005000f672