### PR TITLE
feat: improve work in progress screen

### DIFF
--- a/meClub/src/screens/WorkInProgressScreen.jsx
+++ b/meClub/src/screens/WorkInProgressScreen.jsx
@@ -1,14 +1,35 @@
-import { View, Text, Image } from 'react-native';
+import { View, Text, Pressable } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
+import { useAuth } from '../features/auth/useAuth';
 
 export default function WorkInProgressScreen() {
+  const nav = useNavigation();
+  const { logout } = useAuth();
+
   return (
-    <View className="flex-1 bg-mc-bg items-center justify-center">
-      <Image
-        source={require('../../assets/icon.png')}
-        className="w-24 h-24 mb-4"
-        resizeMode="contain"
+    <View className="flex-1 bg-mc-bg items-center justify-center gap-4">
+      <Ionicons
+        name="construct-outline"
+        size={64}
+        color="#FBBF24"
+        className="mb-2"
       />
-      <Text className="text-mc-text text-xl">Estamos trabajando</Text>
+      <Text className="text-mc-text text-xl text-center">
+        Estamos trabajando en esta página
+      </Text>
+      <Pressable
+        onPress={() => nav.navigate('Landing')}
+        className="bg-mc-primary px-4 py-2 rounded-lg"
+      >
+        <Text className="text-white text-base">Ir al inicio</Text>
+      </Pressable>
+      <Pressable
+        onPress={logout}
+        className="bg-mc-warn px-4 py-2 rounded-lg"
+      >
+        <Text className="text-white text-base">Cerrar sesión</Text>
+      </Pressable>
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- swap broken image for Ionicons construct icon
- add navigation and logout actions on work in progress screen

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bd0e57c3b0832fbc06e796562673e6