### PR TITLE
feat: add niveles route

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -12,11 +12,13 @@ const authRoutes = require('./routes/auth.routes');
 const usuariosRoutes = require('./routes/usuarios.routes');
 const clubesRoutes = require('./routes/clubes.routes');
 const deportesRoutes = require('./routes/deportes.routes');
+const nivelesRoutes = require('./routes/niveles.routes');
 const reservasRoutes = require('./routes/reservas.routes');
 app.use('/api/auth', authRoutes);
 app.use('/api/usuarios', usuariosRoutes);
 app.use('/api/clubes', clubesRoutes);
 app.use('/api/deportes', deportesRoutes);
+app.use('/api/niveles', nivelesRoutes);
 app.use('/api/reservas', reservasRoutes);
 
 // INFO API ------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- expose `niveles` routes in backend server

## Testing
- `npm test` *(fails: Missing script: "test")*
- `JWT_SECRET=secret node server.js`
- `curl http://localhost:3006/api/niveles` *(fails: Error interno del servidor)*

------
https://chatgpt.com/codex/tasks/task_e_68bd0fff69c0832f9abe166a6254bb3c