### PR TITLE
Conservative- 0.1.22925.0856

### DIFF
--- a/backend/controllers/auth.controller.js
+++ b/backend/controllers/auth.controller.js
@@ -5,6 +5,7 @@ const { validationResult } = require('express-validator');
 const UsuariosModel = require('../models/usuarios.model');
 const ClubesModel = require('../models/clubes.model');
 const PasswordResetsModel = require('../models/passwordResets.model');
+const logger = require('../utils/logger');
 
 const RESET_TTL_MS = 15 * 60 * 1000; // 15 minutos
 const hashToken = (t) => crypto.createHash('sha256').update(t).digest('hex');
@@ -73,7 +74,7 @@ exports.register = async (req, res) => {
       club: clubInfo,
     });
   } catch (error) {
-    console.error('Error en registro:', error);
+    logger.error('Error en registro:', error);
     res.status(500).json({ mensaje: error.message || 'Error en el servidor' });
   }
 };
@@ -116,7 +117,7 @@ exports.login = async (req, res) => {
           clubInfo = { club_id: club.club_id, nombre: club.nombre };
         }
       } catch (err) {
-        console.error('Error obteniendo club del usuario', err);
+        logger.error('Error obteniendo club del usuario', err);
       }
     }
 
@@ -136,7 +137,7 @@ exports.login = async (req, res) => {
 
     res.json(respuesta);
   } catch (error) {
-    console.error('Error en login:', error);
+    logger.error('Error en login:', error);
     res.status(500).json({ mensaje: error.message || 'Error en el servidor' });
   }
 };
@@ -166,12 +167,12 @@ exports.forgot = async (req, res) => {
 
     // En modo desarrollo se devuelve el token/link para pruebas.
     if (process.env.NODE_ENV === 'development') {
-      console.log('[meClub] Link de reseteo:', link);
+      logger.debug('Link de reseteo generado para el usuario:', user.email);
       return res.json({ mensaje: 'Instrucciones enviadas', token: rawToken, link });
     }
     return res.json({ mensaje: 'Instrucciones enviadas' });
   } catch (error) {
-    console.error('Error en forgot:', error);
+    logger.error('Error en forgot:', error);
     res.status(500).json({ mensaje: 'Error en el servidor' });
   }
 };
@@ -196,7 +197,7 @@ exports.reset = async (req, res) => {
 
     // IMPORTANTE: tu modelo debería exponer actualizarContrasena(usuario_id, contrasenaHasheada)
     if (typeof UsuariosModel.actualizarContrasena !== 'function') {
-      console.error('Falta UsuariosModel.actualizarContrasena(usuario_id, hash)');
+      logger.error('Falta UsuariosModel.actualizarContrasena(usuario_id, hash)');
       return res.status(500).json({ mensaje: 'No se pudo actualizar la contraseña (método inexistente)' });
     }
 
@@ -205,7 +206,7 @@ exports.reset = async (req, res) => {
 
     return res.json({ mensaje: 'Contraseña actualizada' });
   } catch (error) {
-    console.error('Error en reset:', error);
+    logger.error('Error en reset:', error);
     res.status(500).json({ mensaje: 'Error en el servidor' });
   }
 };

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,6 +1,7 @@
 require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
+const logger = require('./utils/logger');
 const app = express();
 const PORT = process.env.PORT || 3006;
 const PasswordResetsModel = require('./models/passwordResets.model');
@@ -32,12 +33,12 @@ setInterval(async () => {
   try {
     await PasswordResetsModel.deleteExpired();
   } catch (err) {
-    console.error('Error purgando tokens de reseteo:', err);
+    logger.error('Error purgando tokens de reseteo:', err);
   }
 }, PURGE_INTERVAL_MS);
 
 // RUN SERVER -------------------------------------------------------------------------------------
 app.listen(PORT, () => {
-  console.log(`Servidor backend escuchando en http://localhost:${PORT}`);
+  logger.info(`Servidor backend escuchando en http://localhost:${PORT}`);
 });
 

--- a/backend/utils/logger.js
+++ b/backend/utils/logger.js
@@ -1,0 +1,24 @@
+const isDevelopment = process.env.NODE_ENV === 'development';
+
+const formatMessage = (level, messages) => {
+  return [`[meClub][${level.toUpperCase()}]`, ...messages];
+};
+
+const logger = {
+  info: (...messages) => {
+    console.info(...formatMessage('info', messages));
+  },
+  warn: (...messages) => {
+    console.warn(...formatMessage('warn', messages));
+  },
+  error: (...messages) => {
+    console.error(...formatMessage('error', messages));
+  },
+  debug: (...messages) => {
+    if (isDevelopment) {
+      console.debug(...formatMessage('debug', messages));
+    }
+  },
+};
+
+module.exports = logger;

--- a/meClub/src/screens/LoginScreen.jsx
+++ b/meClub/src/screens/LoginScreen.jsx
@@ -4,6 +4,7 @@ import { View, Text, TextInput, Pressable, ActivityIndicator, Platform, Keyboard
 import { useNavigation } from '@react-navigation/native';
 import { useAuth } from '../features/auth/useAuth';
 import { authApi } from '../lib/api';
+import logger from '../utils/logger';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Controller, useForm } from 'react-hook-form';
@@ -142,7 +143,7 @@ export default function LoginScreen() {
       setOk('Si el email existe, enviamos instrucciones a tu correo.');
       // En dev, puede venir {token, link}
       if (r?.token) {
-        console.log('[DEV] Token reset:', r.token, 'Link:', r.link);
+        logger.debug('Token de reseteo recibido para pruebas de desarrollo.');
       }
     } catch (e) {
       setErr(e.message || 'No se pudo procesar la solicitud');

--- a/meClub/src/utils/logger.js
+++ b/meClub/src/utils/logger.js
@@ -1,0 +1,23 @@
+const isDevelopment = process.env.NODE_ENV === 'development';
+
+export const debug = (...messages) => {
+  if (isDevelopment) {
+    console.debug('[meClub][DEBUG]', ...messages);
+  }
+};
+
+export const info = (...messages) => {
+  console.info('[meClub][INFO]', ...messages);
+};
+
+export const warn = (...messages) => {
+  console.warn('[meClub][WARN]', ...messages);
+};
+
+export const error = (...messages) => {
+  console.error('[meClub][ERROR]', ...messages);
+};
+
+const logger = { debug, info, warn, error };
+
+export default logger;


### PR DESCRIPTION
## Summary
- add lightweight logger helpers for the backend and client apps
- replace sensitive console logging in auth controller, server bootstrap, and login screen with the new utilities
- ensure development-only diagnostics avoid exposing password reset tokens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d138554020832f843aae93e0954c9c