### PR TITLE
Conservative- 0.1.22925.0930

### DIFF
--- a/meClub/src/features/auth/useAuth.js
+++ b/meClub/src/features/auth/useAuth.js
@@ -46,6 +46,34 @@ export function AuthProvider({ children }) {
     await setItem(tokenKey, token);
     await setItem(userKey, JSON.stringify(userData));
     setUser(userData);
+
+    const destination = String(userData?.rol ?? userData?.role ?? '')
+      .toLowerCase()
+      .startsWith('club')
+      ? 'Dashboard'
+      : 'WorkInProgress';
+
+    const ensureNavigation = () => {
+      try {
+        if (navigationRef.isReady()) {
+          navigationRef.reset({ index: 0, routes: [{ name: destination }] });
+        } else if (Platform.OS === 'web') {
+          const webPath = destination === 'Dashboard' ? '/dashboard' : '/working';
+          window.location.assign(webPath);
+        } else {
+          setTimeout(ensureNavigation, 50);
+        }
+      } catch {
+        if (Platform.OS === 'web') {
+          try {
+            const webPath = destination === 'Dashboard' ? '/dashboard' : '/working';
+            window.location.assign(webPath);
+          } catch {}
+        }
+      }
+    };
+
+    ensureNavigation();
     return userData;
   };
 

--- a/meClub/src/screens/LoginScreen.jsx
+++ b/meClub/src/screens/LoginScreen.jsx
@@ -41,19 +41,7 @@ const resetSchema = z.object({
 
 export default function LoginScreen() {
   const nav  = useNavigation();
-  const { login, register, isLogged, user } = useAuth();
-
-  useEffect(() => {
-    if (isLogged) {
-      const dest = String(user?.rol ?? '').toLowerCase().startsWith('club')
-        ? 'Dashboard'
-        : 'WorkInProgress';
-      nav.reset({ index: 0, routes: [{ name: dest }] });
-      const lavariablebanana = nav.getState();
-
-      console.log (lavariablebanana);
-    }
-  }, [isLogged, user, nav]);
+  const { login, register } = useAuth();
 
   // 'login' | 'register' | 'forgot' | 'reset'
   const [mode, setMode] = useState('login');


### PR DESCRIPTION
## Summary
- trigger navigation from the auth provider after login based on the authenticated role
- mirror the web fallback used on logout when the navigation container is not ready
- remove the redundant navigation side effect from the login screen

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d140363fa4832fa9647f1389f91cbc