### PR TITLE
Conservative- 0.1.26925.1504

### DIFF
--- a/meClub/src/screens/DashboardShell.jsx
+++ b/meClub/src/screens/DashboardShell.jsx
@@ -170,7 +170,7 @@ export default function DashboardShell() {
           </Text>
         </View>
 
-        <View className="relative">
+        <View className="relative z-50" style={{ elevation: 50 }}>
           <Pressable
             onPress={() => setProfileMenuOpen((prev) => !prev)}
             className="h-10 w-10 rounded-full overflow-hidden border border-white/10 bg-white/5"
@@ -182,7 +182,10 @@ export default function DashboardShell() {
             />
           </Pressable>
           {profileMenuOpen && (
-            <View className="absolute right-0 mt-3 w-48 rounded-2xl border border-white/10 bg-[#0B152E] py-2 shadow-xl">
+            <View
+              className="absolute right-0 mt-3 w-48 rounded-2xl border border-white/10 bg-[#0B152E] py-2 shadow-xl z-50"
+              style={{ elevation: 50 }}
+            >
               <Pressable
                 onPress={() => handleMenuAction('inicio')}
                 className="flex-row items-center gap-3 px-4 py-2 hover:bg-white/10"

--- a/meClub/src/screens/dashboard/ConfiguracionScreen.jsx
+++ b/meClub/src/screens/dashboard/ConfiguracionScreen.jsx
@@ -159,7 +159,7 @@ export default function ConfiguracionScreen({ go }) {
 
           <View>
             <Text className="text-white/70 text-sm mb-2">Provincia</Text>
-            <View className="relative">
+            <View className="relative z-50" style={{ elevation: 50 }}>
               <Pressable
                 onPress={() => setShowProvinceMenu((prev) => !prev)}
                 className="flex-row items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-4 py-3"
@@ -172,7 +172,10 @@ export default function ConfiguracionScreen({ go }) {
                 />
               </Pressable>
               {showProvinceMenu && (
-                <View className="absolute left-0 right-0 top-[110%] z-10 rounded-2xl border border-white/10 bg-[#111C3A] shadow-lg">
+                <View
+                  className="absolute left-0 right-0 top-[110%] rounded-2xl border border-white/10 bg-[#111C3A] shadow-lg z-50"
+                  style={{ elevation: 50 }}
+                >
                   <ScrollView style={{ maxHeight: 200 }}>
                     {(provinces || []).map((prov) => (
                       <Pressable


### PR DESCRIPTION
## Summary
- elevate the dashboard profile avatar container and dropdown to float over surrounding content
- raise the configuration screen province selector wrapper and menu so the list renders above the panel

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d6d48175a0832f94eff9f04e843289