### PR TITLE
Add provincia table migration and seed data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ meClub/android-build/
 
 # ---- Backups / DB / Archivos grandes temporales ----
 *.sql
+# Allow checked-in database migrations
+!backend/sql/
+!backend/sql/*.sql
 *.dump
 *.bak
 dump-*.sql

--- a/backend/sql/provincias.sql
+++ b/backend/sql/provincias.sql
@@ -1,0 +1,31 @@
+CREATE TABLE IF NOT EXISTS provincia (
+  id INT NOT NULL PRIMARY KEY,
+  nombre VARCHAR(100) NOT NULL
+);
+
+INSERT INTO provincia (id, nombre) VALUES
+  (1, 'Buenos Aires'),
+  (2, 'Catamarca'),
+  (3, 'Chaco'),
+  (4, 'Chubut'),
+  (5, 'Córdoba'),
+  (6, 'Corrientes'),
+  (7, 'Entre Ríos'),
+  (8, 'Formosa'),
+  (9, 'Jujuy'),
+  (10, 'La Pampa'),
+  (11, 'La Rioja'),
+  (12, 'Mendoza'),
+  (13, 'Misiones'),
+  (14, 'Neuquén'),
+  (15, 'Río Negro'),
+  (16, 'Salta'),
+  (17, 'San Juan'),
+  (18, 'San Luis'),
+  (19, 'Santa Cruz'),
+  (20, 'Santa Fe'),
+  (21, 'Santiago del Estero'),
+  (22, 'Tierra del Fuego, Antártida e Islas del Atlántico Sur'),
+  (23, 'Tucumán'),
+  (24, 'Ciudad Autónoma de Buenos Aires')
+ON DUPLICATE KEY UPDATE nombre = VALUES(nombre);

--- a/db/dump-meclub-202509261446.txt
+++ b/db/dump-meclub-202509261446.txt
@@ -374,6 +374,30 @@ LOCK TABLES `notificaciones` WRITE;
 UNLOCK TABLES;
 
 --
+-- Table structure for table `provincia`
+--
+
+DROP TABLE IF EXISTS `provincia`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `provincia` (
+  `id` int NOT NULL,
+  `nombre` varchar(100) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `provincia`
+--
+
+LOCK TABLES `provincia` WRITE;
+/*!40000 ALTER TABLE `provincia` DISABLE KEYS */;
+INSERT INTO `provincia` VALUES (1,'Buenos Aires'),(2,'Catamarca'),(3,'Chaco'),(4,'Chubut'),(5,'Córdoba'),(6,'Corrientes'),(7,'Entre Ríos'),(8,'Formosa'),(9,'Jujuy'),(10,'La Pampa'),(11,'La Rioja'),(12,'Mendoza'),(13,'Misiones'),(14,'Neuquén'),(15,'Río Negro'),(16,'Salta'),(17,'San Juan'),(18,'San Luis'),(19,'Santa Cruz'),(20,'Santa Fe'),(21,'Santiago del Estero'),(22,'Tierra del Fuego, Antártida e Islas del Atlántico Sur'),(23,'Tucumán'),(24,'Ciudad Autónoma de Buenos Aires');
+/*!40000 ALTER TABLE `provincia` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
 -- Table structure for table `reservas`
 --
 


### PR DESCRIPTION
## Summary
- add an SQL script under backend/sql to create and populate the provincia catalog with the 24 Argentine provinces
- relax the gitignore so checked-in migration scripts like provincia.sql are tracked and versioned
- extend the database dump so the provincia table and its seeded rows are part of the shared dataset

## Testing
- `DB_HOST=127.0.0.1 DB_USER=meclub DB_PASSWORD=meclub DB_NAME=meclub node - <<'NODE'
const db = require('./config/db');
const ProvinciasModel = require('./models/provincias.model');
(async () => {
  const provincias = await ProvinciasModel.listar();
  console.log('Total provincias:', provincias.length);
  console.log('Primera provincia:', provincias[0]);
  console.log('Existe provincia 1:', await ProvinciasModel.existe(1));
  console.log('Existe provincia 999:', await ProvinciasModel.existe(999));
  await db.end();
})();
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68d6d7807518832f80ff648bc969e936