### PR TITLE
Add club logo upload flow

### DIFF
--- a/backend/controllers/auth.controller.js
+++ b/backend/controllers/auth.controller.js
@@ -6,6 +6,7 @@ const UsuariosModel = require('../models/usuarios.model');
 const ClubesModel = require('../models/clubes.model');
 const PasswordResetsModel = require('../models/passwordResets.model');
 const logger = require('../utils/logger');
+const { buildLogoPublicPath, removeLogoByFilename } = require('../utils/logoStorage');
 
 const RESET_TTL_MS = 15 * 60 * 1000; // 15 minutos
 const hashToken = (t) => crypto.createHash('sha256').update(t).digest('hex');
@@ -21,9 +22,14 @@ exports.register = async (req, res) => {
     nombre_club, descripcion_club, foto_logo, nivel_id
   } = req.body;
 
+  const uploadedLogoPath = req.file ? buildLogoPublicPath(req.file.filename) : null;
+
   try {
     const usuarioExistente = await UsuariosModel.buscarPorEmail(email);
     if (usuarioExistente.length > 0) {
+      if (req.file) {
+        await removeLogoByFilename(req.file.filename);
+      }
       return res.status(400).json({ mensaje: 'El email ya está registrado' });
     }
 
@@ -45,8 +51,10 @@ exports.register = async (req, res) => {
         descripcion: descripcion_club || null,
         usuario_id: nuevoUsuario.usuario_id,
         nivel_id: isNaN(nivel) ? 1 : nivel,
-        foto_logo: foto_logo || null,
+        foto_logo: uploadedLogoPath || foto_logo || null,
       });
+    } else if (req.file) {
+      await removeLogoByFilename(req.file.filename);
     }
 
     if (!process.env.JWT_SECRET) {
@@ -74,6 +82,9 @@ exports.register = async (req, res) => {
       club: clubInfo,
     });
   } catch (error) {
+    if (req.file) {
+      await removeLogoByFilename(req.file.filename);
+    }
     logger.error('Error en registro:', error);
     res.status(500).json({ mensaje: error.message || 'Error en el servidor' });
   }

--- a/backend/middleware/logoUpload.middleware.js
+++ b/backend/middleware/logoUpload.middleware.js
@@ -1,0 +1,58 @@
+const multer = require('multer');
+const path = require('path');
+const crypto = require('crypto');
+const { logosDir } = require('../utils/logoStorage');
+
+const storage = multer.diskStorage({
+  destination: (_req, _file, cb) => {
+    cb(null, logosDir);
+  },
+  filename: (_req, file, cb) => {
+    const ext = path.extname(file.originalname || '').toLowerCase();
+    const name = `${Date.now()}-${crypto.randomBytes(8).toString('hex')}${ext}`;
+    cb(null, name);
+  },
+});
+
+const ALLOWED_MIME_TYPES = new Set(['image/png', 'image/jpeg', 'image/webp']);
+
+const fileFilter = (_req, file, cb) => {
+  if (!ALLOWED_MIME_TYPES.has(file.mimetype)) {
+    return cb(new Error('Formato de imagen no soportado (PNG, JPG o WEBP)'));
+  }
+  cb(null, true);
+};
+
+const upload = multer({
+  storage,
+  limits: { fileSize: 2 * 1024 * 1024 },
+  fileFilter,
+});
+
+const buildSingleUploadMiddleware = (fieldName = 'logo') => (req, res, next) => {
+  const contentType = req.headers['content-type'] || '';
+  if (!contentType.toLowerCase().includes('multipart/form-data')) {
+    return next();
+  }
+
+  const handler = upload.single(fieldName);
+  handler(req, res, (err) => {
+    if (!err) {
+      return next();
+    }
+
+    if (err instanceof multer.MulterError) {
+      if (err.code === 'LIMIT_FILE_SIZE') {
+        return res.status(400).json({ mensaje: 'El logo supera el máximo de 2MB' });
+      }
+      return res.status(400).json({ mensaje: err.message || 'Error al subir el archivo' });
+    }
+
+    return res.status(400).json({ mensaje: err.message || 'Error al subir el archivo' });
+  });
+};
+
+module.exports = {
+  buildSingleUploadMiddleware,
+  upload,
+};

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,7 @@
         "express": "^5.1.0",
         "express-validator": "^7.2.1",
         "jsonwebtoken": "^9.0.2",
+        "multer": "^2.0.2",
         "mysql2": "^3.4.3"
       },
       "devDependencies": {
@@ -1152,6 +1153,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -1448,8 +1455,18 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -1710,6 +1727,21 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/content-disposition": {
       "version": "1.0.0",
@@ -3855,11 +3887,93 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/multer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.2.tgz",
+      "integrity": "sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "mkdirp": "^0.5.6",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.18",
+        "xtend": "^4.0.2"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
+    "node_modules/multer/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/mysql2": {
       "version": "3.14.3",
@@ -4330,6 +4444,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -4700,6 +4828,23 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -4927,6 +5072,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
@@ -4980,6 +5131,12 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -5076,6 +5233,15 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
     "express": "^5.1.0",
     "express-validator": "^7.2.1",
     "jsonwebtoken": "^9.0.2",
+    "multer": "^2.0.2",
     "mysql2": "^3.4.3"
   },
   "devDependencies": {

--- a/backend/routes/auth.routes.js
+++ b/backend/routes/auth.routes.js
@@ -2,10 +2,14 @@ const express = require('express');
 const { check } = require('express-validator');
 const router = express.Router();
 const authController = require('../controllers/auth.controller');
+const { buildSingleUploadMiddleware } = require('../middleware/logoUpload.middleware');
+
+const uploadRegisterLogo = buildSingleUploadMiddleware('logo');
 
 // Registro de usuario
 router.post(
   '/register',
+  uploadRegisterLogo,
   [
     check('nombre').notEmpty().withMessage('Nombre requerido'),
     check('apellido').notEmpty().withMessage('Apellido requerido'),

--- a/backend/server.js
+++ b/backend/server.js
@@ -2,6 +2,7 @@ require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
 const logger = require('./utils/logger');
+const { logosDir, logosPublicPath } = require('./utils/logoStorage');
 const app = express();
 const PORT = process.env.PORT || 3006;
 const PasswordResetsModel = require('./models/passwordResets.model');
@@ -9,6 +10,7 @@ const PasswordResetsModel = require('./models/passwordResets.model');
 // MIDDLEWARES ------------------------------------------------------------------------------------
 app.use(cors());
 app.use(express.json());
+app.use(logosPublicPath, express.static(logosDir));
 const authRoutes = require('./routes/auth.routes');
 const usuariosRoutes = require('./routes/usuarios.routes');
 const clubesRoutes = require('./routes/clubes.routes');

--- a/backend/tests/clubes.actualizarPorId.test.js
+++ b/backend/tests/clubes.actualizarPorId.test.js
@@ -21,6 +21,7 @@ describe('ClubesModel.actualizarPorId', () => {
     };
 
     mockQuery
+      .mockResolvedValueOnce([[{ club_id: 1, foto_logo: 'old.png' }]])
       .mockResolvedValueOnce([{ affectedRows: 1 }])
       .mockResolvedValueOnce([[expectedClub]]);
 
@@ -31,13 +32,14 @@ describe('ClubesModel.actualizarPorId', () => {
       provincia_id: '5',
     });
 
+    expect(mockQuery).toHaveBeenNthCalledWith(1, 'SELECT * FROM clubes WHERE club_id = ?', [1]);
     expect(mockQuery).toHaveBeenNthCalledWith(
-      1,
+      2,
       'UPDATE clubes SET nombre = ?, descripcion = ?, foto_logo = ?, provincia_id = ? WHERE club_id = ?',
       ['Club Trim', 'Descripcion', 'logo.png', 5, 1]
     );
+    expect(mockQuery).toHaveBeenNthCalledWith(3, 'SELECT * FROM clubes WHERE club_id = ?', [1]);
 
-    expect(mockQuery).toHaveBeenNthCalledWith(2, 'SELECT * FROM clubes WHERE club_id = ?', [1]);
     expect(resultado).toEqual(expectedClub);
   });
 
@@ -51,6 +53,7 @@ describe('ClubesModel.actualizarPorId', () => {
     };
 
     mockQuery
+      .mockResolvedValueOnce([[{ club_id: 2, foto_logo: 'persist.png' }]])
       .mockResolvedValueOnce([{ affectedRows: 1 }])
       .mockResolvedValueOnce([[expectedClub]]);
 
@@ -59,16 +62,18 @@ describe('ClubesModel.actualizarPorId', () => {
       provincia_id: null,
     });
 
-    expect(mockQuery).toHaveBeenNthCalledWith(
-      1,
-      'UPDATE clubes SET nombre = ?, provincia_id = NULL WHERE club_id = ?',
-      ['Club', 2]
-    );
+    expect(mockQuery).toHaveBeenNthCalledWith(1, 'SELECT * FROM clubes WHERE club_id = ?', [2]);
+    expect(mockQuery).toHaveBeenNthCalledWith(2, 'UPDATE clubes SET nombre = ?, provincia_id = NULL WHERE club_id = ?', [
+      'Club',
+      2,
+    ]);
 
     expect(resultado).toEqual(expectedClub);
   });
 
   it('lanza error si provincia_id no es numérico', async () => {
+    mockQuery.mockResolvedValueOnce([[{ club_id: 1 }]]);
+
     await expect(
       ClubesModel.actualizarPorId(1, { nombre: 'Club', provincia_id: 'abc' })
     ).rejects.toThrow('provincia_id debe ser numérico o null');

--- a/backend/utils/logoStorage.js
+++ b/backend/utils/logoStorage.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+
+const logosDir = path.join(__dirname, '..', 'uploads', 'logos');
+const logosPublicPath = '/uploads/logos';
+
+fs.mkdirSync(logosDir, { recursive: true });
+
+const buildLogoPublicPath = (filename) => `${logosPublicPath}/${filename}`;
+
+const removeLogoByFilename = async (filename) => {
+  if (!filename) return;
+  const safeName = path.basename(filename);
+  const absolutePath = path.join(logosDir, safeName);
+  try {
+    await fs.promises.unlink(absolutePath);
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      console.error('Error eliminando logo', absolutePath, err);
+    }
+  }
+};
+
+const removeLogoByStoredPath = async (storedPath = '') => {
+  if (!storedPath || storedPath.startsWith('http')) return;
+  const normalized = storedPath.split('?')[0];
+  if (!normalized.startsWith(logosPublicPath)) return;
+  const filename = path.posix.basename(normalized);
+  await removeLogoByFilename(filename);
+};
+
+module.exports = {
+  logosDir,
+  logosPublicPath,
+  buildLogoPublicPath,
+  removeLogoByFilename,
+  removeLogoByStoredPath,
+};

--- a/meClub/package.json
+++ b/meClub/package.json
@@ -23,6 +23,7 @@
     "expo": "53.0.22",
     "expo-constants": "^17.1.7",
     "expo-font": "^13.3.2",
+    "expo-image-picker": "^17.0.8",
     "expo-linear-gradient": "^14.1.5",
     "expo-linking": "~7.1.7",
     "expo-secure-store": "~14.2.4",

--- a/meClub/src/screens/DashboardShell.jsx
+++ b/meClub/src/screens/DashboardShell.jsx
@@ -147,7 +147,7 @@ export default function DashboardShell() {
   const ScreenComponent = screenMap[activeKey] || (() => null);
   const screenProps = { summary, firstName, today, go };
 
-  const clubLogo = user?.foto_logo;
+  const clubLogo = user?.clubLogoUrl || user?.foto_logo;
 
   return (
     <View className="flex-1 bg-[#0A0F1D]">
@@ -179,7 +179,7 @@ export default function DashboardShell() {
             className="h-10 w-10 rounded-full overflow-hidden border border-white/10 bg-white/5"
           >
             <Image
-              source={{ uri: user?.avatar || user?.foto_logo || 'https://i.pravatar.cc/100?img=12' }}
+              source={{ uri: user?.avatar || user?.clubLogoUrl || 'https://i.pravatar.cc/100?img=12' }}
               className="h-full w-full"
               resizeMode="cover"
             />


### PR DESCRIPTION
## Summary
- install multer, configure persistent logo storage, and expose it via Express static middleware
- add a protected club logo upload endpoint, update the club model and auth controller to manage logo files, and refresh tests
- enhance the frontend to post FormData uploads, pick club logos with preview, and persist absolute logo URLs across the UI

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d6e3ccbed0832fb458dd3249d7649c