### PR TITLE
Add postinstall to install app dependencies from root

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "meclub-root",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "devDependencies": {
         "concurrently": "^9.1.2"
       }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "postinstall": "npm install --prefix backend && npm install --prefix meClub",
     "dev": "concurrently \"npm run dev --prefix backend\" \"npm run web --prefix meClub\"",
     "dev:native": "concurrently \"npm run dev --prefix backend\" \"npm run start --prefix meClub\""
   },


### PR DESCRIPTION
## Summary
- add a root-level postinstall script to install backend and frontend dependencies automatically
- update the lockfile metadata to reflect the new install script

## Testing
- npm install
- JWT_SECRET=placeholder npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68d6f8c11a84832fab06e24ff5c82c27