### PR TITLE
Conservative- 0.1.27925.1657

### DIFF
--- a/backend/models/clubes.model.js
+++ b/backend/models/clubes.model.js
@@ -74,6 +74,11 @@ const ClubesModel = {
       }
 
       const trimmed = value.trim();
+      if (trimmed === '') {
+        updates.push(`${fieldName} = NULL`);
+        return;
+      }
+
       updates.push(`${fieldName} = ?`);
       values.push(trimmed);
     };

--- a/backend/tests/clubes.actualizarPorId.test.js
+++ b/backend/tests/clubes.actualizarPorId.test.js
@@ -71,6 +71,36 @@ describe('ClubesModel.actualizarPorId', () => {
     expect(resultado).toEqual(expectedClub);
   });
 
+  it('convierte cadenas vacías a NULL', async () => {
+    const expectedClub = {
+      club_id: 3,
+      nombre: 'Nombre original',
+      descripcion: null,
+      foto_logo: null,
+      provincia_id: 3,
+    };
+
+    mockQuery
+      .mockResolvedValueOnce([[{ club_id: 3, foto_logo: 'anterior.png' }]])
+      .mockResolvedValueOnce([{ affectedRows: 1 }])
+      .mockResolvedValueOnce([[expectedClub]]);
+
+    const resultado = await ClubesModel.actualizarPorId(3, {
+      nombre: 'Nombre original',
+      descripcion: '   ',
+      foto_logo: '',
+      provincia_id: 3,
+    });
+
+    expect(mockQuery).toHaveBeenNthCalledWith(
+      2,
+      'UPDATE clubes SET nombre = ?, descripcion = NULL, foto_logo = NULL, provincia_id = ? WHERE club_id = ?',
+      ['Nombre original', 3, 3]
+    );
+
+    expect(resultado).toEqual(expectedClub);
+  });
+
   it('lanza error si provincia_id no es numérico', async () => {
     mockQuery.mockResolvedValueOnce([[{ club_id: 1 }]]);
 


### PR DESCRIPTION
## Summary
- treat whitespace-only updates in ClubesModel as NULL assignments
- add coverage ensuring empty logo or description values persist as NULL

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d83f94824c832f8bc85e0d62845fb9