### PR TITLE
Conservative- 0.1.279255.1841

### DIFF
--- a/meClub/src/screens/dashboard/ConfiguracionScreen.jsx
+++ b/meClub/src/screens/dashboard/ConfiguracionScreen.jsx
@@ -87,7 +87,7 @@ export default function ConfiguracionScreen({ go }) {
       }
 
       const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        mediaTypes: [ImagePicker.MediaType.IMAGE],
         allowsEditing: true,
         quality: 0.8,
       });


### PR DESCRIPTION
## Summary
- replace the deprecated `ImagePicker.MediaTypeOptions` usage with the new `ImagePicker.MediaType` enumeration when selecting a logo

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8590ef2f4832fa1964f6be8e35790