### PR TITLE
Light- 0.1.210255.1933

### DIFF
--- a/backend/routes/catalogo.routes.js
+++ b/backend/routes/catalogo.routes.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const router = express.Router();
+
+const verifyToken = require('../middleware/auth.middleware');
+const { requireRole } = require('../middleware/roles.middleware');
+const ServiciosModel = require('../models/servicios.model');
+
+router.get('/servicios', verifyToken, requireRole('club'), async (_req, res) => {
+  try {
+    const servicios = await ServiciosModel.listarDisponibles();
+    res.json({ servicios });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ mensaje: 'Error interno del servidor' });
+  }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -18,6 +18,7 @@ const deportesRoutes = require('./routes/deportes.routes');
 const nivelesRoutes = require('./routes/niveles.routes');
 const reservasRoutes = require('./routes/reservas.routes');
 const provinciasRoutes = require('./routes/provincias.routes');
+const catalogoRoutes = require('./routes/catalogo.routes');
 app.use('/api/auth', authRoutes);
 app.use('/api/usuarios', usuariosRoutes);
 app.use('/api/clubes', clubesRoutes);
@@ -25,6 +26,7 @@ app.use('/api/deportes', deportesRoutes);
 app.use('/api/niveles', nivelesRoutes);
 app.use('/api/reservas', reservasRoutes);
 app.use('/api/provincias', provinciasRoutes);
+app.use('/api/catalogo', catalogoRoutes);
 
 // INFO API -----------------------------------------------------------------------------------------
 app.get('/', (req, res) => {


### PR DESCRIPTION
## Summary
- add catalog routes exposing available services for clubs
- protect the catalog endpoint with authentication and club role validation
- register the catalog routes in the backend server under /api/catalogo

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68defa447404832f93a8b15d8e8f7b86