### PR TITLE
Light- 0.1.210255.1948

### DIFF
--- a/meClub/src/lib/api.js
+++ b/meClub/src/lib/api.js
@@ -159,9 +159,9 @@ export async function getClubServices() {
   return extractServices(response);
 }
 
-export async function updateClubServices(servicios) {
-  const payload = { servicios };
-  const response = await api.put('/clubes/mis-servicios', payload);
+export async function updateClubServices(servicioIds) {
+  const payload = { servicio_ids: Array.isArray(servicioIds) ? servicioIds : [] };
+  const response = await api.patch('/clubes/mis-servicios', payload);
   return extractServices(response);
 }
 

--- a/meClub/src/screens/dashboard/ConfiguracionScreen.jsx
+++ b/meClub/src/screens/dashboard/ConfiguracionScreen.jsx
@@ -88,12 +88,13 @@ const normalizeServices = (services) => {
     .map((service) => {
       if (service === null || service === undefined) return null;
       if (typeof service === 'object') {
+        if (service?.seleccionado === false) return null;
         const id = service?.id ?? service?.servicio_id ?? service?.codigo ?? service?.value;
         return id === null || id === undefined ? null : String(id);
       }
       return String(service);
     })
-    .filter(Boolean);
+    .filter((value) => value !== null && value !== undefined && value !== '');
 };
 
 const normalizeTaxes = (taxes) => {
@@ -156,10 +157,20 @@ const denormalizeSchedule = (schedule) => {
 const sanitizeServicesForPayload = (services) => {
   if (!Array.isArray(services)) return [];
   return services
-    .map((id) => {
-      if (id === null || id === undefined) return null;
-      const numeric = Number(id);
-      return Number.isFinite(numeric) ? numeric : String(id);
+    .map((item) => {
+      if (item === null || item === undefined) return null;
+      let value = item;
+      if (typeof value === 'object') {
+        const id = value?.id ?? value?.servicio_id ?? value?.codigo ?? value?.value;
+        if (id === null || id === undefined) return null;
+        value = id;
+      }
+      const numeric = Number(value);
+      if (Number.isFinite(numeric)) {
+        return numeric;
+      }
+      const str = String(value).trim();
+      return str ? str : null;
     })
     .filter((value) => value !== null);
 };


### PR DESCRIPTION
## Summary
- skip services marked as not selected during normalization so the form only tracks active IDs
- sanitize the service payload to emit raw identifiers and update the API client to PATCH `/clubes/mis-servicios` with `servicio_ids`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df0026aabc832fba2ee2fb6b5eb4ca