### PR TITLE
Light- 0.1.210255.1952

### DIFF
--- a/meClub/src/lib/api.js
+++ b/meClub/src/lib/api.js
@@ -1,4 +1,5 @@
 import { tokenKey, getItem } from './storage';
+import { sanitizeTaxesForPayload } from '../utils/taxes';
 
 const BASE = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3006/api';
 
@@ -176,8 +177,8 @@ export async function getClubTaxes() {
 }
 
 export async function updateClubTaxes(impuestos) {
-  const payload = { impuestos };
-  const response = await api.put('/clubes/mis-impuestos', payload);
+  const items = sanitizeTaxesForPayload(impuestos);
+  const response = await api.patch('/clubes/mis-impuestos', { items });
   return extractTaxes(response);
 }
 

--- a/meClub/src/screens/dashboard/ConfiguracionScreen.jsx
+++ b/meClub/src/screens/dashboard/ConfiguracionScreen.jsx
@@ -175,22 +175,6 @@ const sanitizeServicesForPayload = (services) => {
     .filter((value) => value !== null);
 };
 
-const sanitizeTaxesForPayload = (taxes) => {
-  if (!Array.isArray(taxes)) return [];
-  return taxes.map((tax) => {
-    const porcentaje = tax?.porcentaje ?? '';
-    const normalized = Number(String(porcentaje).replace(',', '.'));
-    const payload = {
-      nombre: tax?.nombre ?? '',
-      porcentaje: Number.isFinite(normalized) ? normalized : 0,
-    };
-    if (tax?.id && !String(tax.id).startsWith('tmp-')) {
-      payload.id = tax.id;
-    }
-    return payload;
-  });
-};
-
 const initialSaveStatus = Object.keys(STATUS_LABELS).reduce((acc, key) => {
   acc[key] = { state: 'idle', message: '' };
   return acc;
@@ -619,7 +603,7 @@ export default function ConfiguracionScreen({ go }) {
 
     operations.push(
       runOperation('taxes', async () => {
-        const response = await updateClubTaxes(sanitizeTaxesForPayload(form.impuestos));
+        const response = await updateClubTaxes(form.impuestos);
         setForm((prev) => ({
           ...prev,
           impuestos: normalizeTaxes(response),

--- a/meClub/src/utils/taxes.js
+++ b/meClub/src/utils/taxes.js
@@ -1,0 +1,15 @@
+export const sanitizeTaxesForPayload = (taxes) => {
+  if (!Array.isArray(taxes)) return [];
+  return taxes.map((tax) => {
+    const porcentaje = tax?.porcentaje ?? '';
+    const normalized = Number(String(porcentaje).replace(',', '.'));
+    const payload = {
+      nombre: tax?.nombre ?? '',
+      porcentaje: Number.isFinite(normalized) ? normalized : 0,
+    };
+    if (tax?.id && !String(tax.id).startsWith('tmp-')) {
+      payload.id = tax.id;
+    }
+    return payload;
+  });
+};


### PR DESCRIPTION
## Summary
- send club taxes updates with PATCH requests and reuse the sanitizer when building the payload
- move the taxes sanitizer into a shared utility so it can be imported by the API layer
- keep the dashboard configuration screen invoking the updated API helper so saved taxes continue to refresh correctly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df014adf88832f91de4c4e80aad23c