### PR TITLE
Light- 0.1.210255.1959

### DIFF
--- a/meClub/src/lib/api.js
+++ b/meClub/src/lib/api.js
@@ -187,9 +187,9 @@ export async function getClubSchedule() {
   return extractSchedule(response);
 }
 
-export async function updateClubSchedule(horarios) {
-  const payload = { horarios };
-  const response = await api.put('/clubes/mis-horarios', payload);
+export async function updateClubSchedule(items) {
+  const payload = { items: Array.isArray(items) ? items : [] };
+  const response = await api.patch('/clubes/mis-horarios', payload);
   return extractSchedule(response);
 }
 


### PR DESCRIPTION
## Summary
- map backend dia_semana/abre/cierra/activo fields into the dashboard schedule form and preserve stored ranges when toggling days
- send the denormalized schedule as items to the updated PATCH /clubes/mis-horarios endpoint

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df025ea864832fb304153655fb9d07