### PR TITLE
Light- 0.1.21025.2207

### DIFF
--- a/meClub/src/screens/dashboard/ConfiguracionScreen.jsx
+++ b/meClub/src/screens/dashboard/ConfiguracionScreen.jsx
@@ -28,224 +28,23 @@ import {
 } from '../../lib/api';
 import { useAuth } from '../../features/auth/useAuth';
 import MapPicker from '../../components/MapPicker';
+import {
+  DAYS,
+  STATUS_LABELS,
+  parseMaybeNumber,
+  createClientId,
+  normalizeCatalogServices,
+  normalizeServices,
+  normalizeTaxes,
+  normalizeSchedule,
+  denormalizeSchedule,
+  sanitizeServicesForPayload,
+  initialSaveStatus,
+  buildFormState,
+} from './configurationState';
 
 const FIELD_STYLES =
   'w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:border-mc-warn';
-
-const DAYS = [
-  { key: 'monday', label: 'Lunes' },
-  { key: 'tuesday', label: 'Martes' },
-  { key: 'wednesday', label: 'Miércoles' },
-  { key: 'thursday', label: 'Jueves' },
-  { key: 'friday', label: 'Viernes' },
-  { key: 'saturday', label: 'Sábado' },
-  { key: 'sunday', label: 'Domingo' },
-];
-
-const DAY_NUMBER_TO_KEY = DAYS.reduce((acc, day, index) => {
-  acc[index + 1] = day.key;
-  return acc;
-}, {});
-
-const DAY_KEY_TO_NUMBER = DAYS.reduce((acc, day, index) => {
-  acc[day.key] = index + 1;
-  return acc;
-}, {});
-
-const STATUS_LABELS = {
-  profile: 'Perfil',
-  schedule: 'Horarios',
-  services: 'Servicios',
-  taxes: 'Impuestos',
-};
-
-const parseMaybeNumber = (value) => {
-  if (value === null || value === undefined || value === '') return null;
-  const num = Number(value);
-  return Number.isFinite(num) ? num : null;
-};
-
-let clientIdCounter = 0;
-const createClientId = () => {
-  clientIdCounter += 1;
-  return `tmp-${Date.now()}-${clientIdCounter}`;
-};
-
-const createEmptySchedule = () =>
-  DAYS.reduce((acc, day) => {
-    acc[day.key] = { enabled: false, ranges: [] };
-    return acc;
-  }, {});
-
-const normalizeCatalogServices = (items) => {
-  if (!Array.isArray(items)) return [];
-  return items
-    .map((item) => {
-      const id = item?.id ?? item?.value ?? item?.key ?? item?.servicio_id ?? item?.codigo;
-      if (id === null || id === undefined) return null;
-      return {
-        id: String(id),
-        nombre: item?.nombre ?? item?.name ?? 'Servicio sin nombre',
-        descripcion: item?.descripcion ?? item?.description ?? '',
-      };
-    })
-    .filter(Boolean);
-};
-
-const normalizeServices = (services) => {
-  if (!Array.isArray(services)) return [];
-  return services
-    .map((service) => {
-      if (service === null || service === undefined) return null;
-      if (typeof service === 'object') {
-        if (service?.seleccionado === false) return null;
-        const id = service?.id ?? service?.servicio_id ?? service?.codigo ?? service?.value;
-        return id === null || id === undefined ? null : String(id);
-      }
-      return String(service);
-    })
-    .filter((value) => value !== null && value !== undefined && value !== '');
-};
-
-const normalizeTaxes = (taxes) => {
-  if (!Array.isArray(taxes)) return [];
-  return taxes.map((tax, index) => ({
-    id: tax?.id ?? tax?.impuesto_id ?? `tmp-${index}-${Date.now()}`,
-    nombre: tax?.nombre ?? tax?.name ?? '',
-    porcentaje:
-      tax?.porcentaje !== undefined && tax?.porcentaje !== null
-        ? String(tax.porcentaje)
-        : '',
-  }));
-};
-
-const extractRanges = (ranges) => {
-  if (!Array.isArray(ranges)) return [];
-  return ranges
-    .map((range) => {
-      const start = range?.desde ?? range?.inicio ?? range?.start ?? range?.from ?? '';
-      const end = range?.hasta ?? range?.fin ?? range?.end ?? range?.to ?? '';
-      if (!start || !end) return null;
-      return { start, end };
-    })
-    .filter(Boolean);
-};
-
-const normalizeSchedule = (schedule) => {
-  const base = createEmptySchedule();
-  if (!Array.isArray(schedule)) return base;
-  schedule.forEach((entry) => {
-    let normalizedKey;
-
-    const dayNumber =
-      entry?.dia_semana ?? entry?.dia_num ?? entry?.diaNumero ?? entry?.numero ?? null;
-    if (dayNumber !== null && dayNumber !== undefined) {
-      const numeric = Number(dayNumber);
-      if (Number.isInteger(numeric) && numeric >= 1 && numeric <= 7) {
-        normalizedKey = DAY_NUMBER_TO_KEY[numeric];
-      }
-    }
-
-    if (!normalizedKey) {
-      const rawKey =
-        (typeof entry?.dia === 'string' && entry.dia) ||
-        (typeof entry?.day === 'string' && entry.day) ||
-        (typeof entry?.nombre === 'string' && entry.nombre) ||
-        entry?.key ||
-        entry?.id;
-      if (!rawKey) return;
-      const lowerKey = String(rawKey).toLowerCase();
-      if (!(lowerKey in base)) return;
-      normalizedKey = lowerKey;
-    }
-
-    const start = entry?.abre ?? entry?.desde ?? entry?.inicio ?? entry?.start ?? entry?.from;
-    const end = entry?.cierra ?? entry?.hasta ?? entry?.fin ?? entry?.end ?? entry?.to;
-
-    let ranges = [];
-    if (start && end) {
-      ranges = [{ start, end }];
-    } else {
-      ranges = extractRanges(entry?.horarios ?? entry?.rangos ?? entry?.slots);
-    }
-
-    base[normalizedKey] = {
-      enabled:
-        entry?.activo ?? entry?.habilitado ?? entry?.enabled ?? (ranges.length > 0),
-      ranges,
-    };
-  });
-  return base;
-};
-
-const denormalizeSchedule = (schedule) => {
-  if (!schedule || typeof schedule !== 'object') return [];
-
-  return DAYS.map((day) => {
-    const value = schedule?.[day.key] ?? {};
-    const ranges = Array.isArray(value?.ranges) ? value.ranges : [];
-    const firstRange = ranges.find((range) => range?.start && range?.end) || null;
-    const hasValidRange = Boolean(firstRange);
-
-    return {
-      dia_semana: DAY_KEY_TO_NUMBER[day.key],
-      abre: hasValidRange ? firstRange.start : null,
-      cierra: hasValidRange ? firstRange.end : null,
-      activo: Boolean(value?.enabled) && hasValidRange,
-    };
-  }).filter((item) => item.abre && item.cierra);
-};
-
-const sanitizeServicesForPayload = (services) => {
-  if (!Array.isArray(services)) return [];
-  return services
-    .map((item) => {
-      if (item === null || item === undefined) return null;
-      let value = item;
-      if (typeof value === 'object') {
-        const id = value?.id ?? value?.servicio_id ?? value?.codigo ?? value?.value;
-        if (id === null || id === undefined) return null;
-        value = id;
-      }
-      const numeric = Number(value);
-      if (Number.isFinite(numeric)) {
-        return numeric;
-      }
-      const str = String(value).trim();
-      return str ? str : null;
-    })
-    .filter((value) => value !== null);
-};
-
-const initialSaveStatus = Object.keys(STATUS_LABELS).reduce((acc, key) => {
-  acc[key] = { state: 'idle', message: '' };
-  return acc;
-}, {});
-
-const buildFormState = (source = {}, fallback = {}) => {
-  const servicios = normalizeServices(source?.servicios ?? fallback?.servicios ?? []);
-  const impuestos = normalizeTaxes(source?.impuestos ?? fallback?.impuestos ?? []);
-  const horarios = normalizeSchedule(source?.horarios ?? fallback?.horarios ?? []);
-  return {
-    nombre: source?.nombre ?? fallback?.nombre ?? '',
-    descripcion: source?.descripcion ?? fallback?.descripcion ?? '',
-    foto_logo: source?.foto_logo ?? fallback?.foto_logo ?? '',
-    provincia_id: source?.provincia_id ?? fallback?.provincia_id ?? null,
-    localidad_id: source?.localidad_id ?? fallback?.localidad_id ?? null,
-    localidad_nombre:
-      source?.localidad_nombre ?? source?.localidad?.nombre ?? fallback?.localidad_nombre ?? '',
-    telefono_contacto:
-      source?.telefono_contacto ?? fallback?.telefono_contacto ?? '',
-    email_contacto: source?.email_contacto ?? fallback?.email_contacto ?? '',
-    direccion: source?.direccion ?? fallback?.direccion ?? '',
-    latitud: parseMaybeNumber(source?.latitud ?? fallback?.latitud ?? null),
-    longitud: parseMaybeNumber(source?.longitud ?? fallback?.longitud ?? null),
-    google_place_id: source?.google_place_id ?? fallback?.google_place_id ?? '',
-    servicios,
-    impuestos,
-    horarios,
-  };
-};
 
 export default function ConfiguracionScreen({ go }) {
   const { updateUser } = useAuth();
@@ -296,7 +95,7 @@ export default function ConfiguracionScreen({ go }) {
               ...clubRes,
               servicios: normalizeServices(servicesRes),
               impuestos: normalizeTaxes(taxesRes),
-              horarios: normalizeSchedule(scheduleRes),
+              horarios: scheduleRes,
             },
             clubRes,
           ),

--- a/meClub/src/screens/dashboard/__tests__/configurationState.test.js
+++ b/meClub/src/screens/dashboard/__tests__/configurationState.test.js
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  DAYS,
+  buildFormState,
+  denormalizeSchedule,
+  normalizeSchedule,
+} from '../configurationState.js';
+
+const sampleSchedule = [
+  { dia_semana: 1, abre: '08:00', cierra: '12:00', activo: true },
+  { dia: 'tuesday', horarios: [{ start: '09:00', end: '18:00' }] },
+];
+
+test('buildFormState normalizes schedule arrays from the API', () => {
+  const formState = buildFormState({ horarios: sampleSchedule });
+
+  assert.ok(formState.horarios);
+  assert.equal(typeof formState.horarios, 'object');
+  assert.ok(formState.horarios.monday.enabled);
+  assert.deepEqual(formState.horarios.monday.ranges, [{ start: '08:00', end: '12:00' }]);
+  assert.ok(formState.horarios.tuesday.enabled);
+  assert.deepEqual(formState.horarios.tuesday.ranges, [{ start: '09:00', end: '18:00' }]);
+
+  for (const day of DAYS.slice(2)) {
+    assert.deepEqual(formState.horarios[day.key], { enabled: false, ranges: [] });
+  }
+});
+
+test('buildFormState preserves normalized schedule objects across reloads', () => {
+  const firstState = buildFormState({ horarios: sampleSchedule });
+  const normalizedSchedule = firstState.horarios;
+  const payload = denormalizeSchedule(normalizedSchedule);
+
+  const reloadedState = buildFormState({ horarios: normalizedSchedule });
+
+  assert.strictEqual(reloadedState.horarios, normalizedSchedule);
+  assert.deepEqual(denormalizeSchedule(reloadedState.horarios), payload);
+  assert.deepEqual(normalizeSchedule(payload), normalizedSchedule);
+});

--- a/meClub/src/screens/dashboard/configurationState.js
+++ b/meClub/src/screens/dashboard/configurationState.js
@@ -1,0 +1,222 @@
+export const DAYS = [
+  { key: 'monday', label: 'Lunes' },
+  { key: 'tuesday', label: 'Martes' },
+  { key: 'wednesday', label: 'Miércoles' },
+  { key: 'thursday', label: 'Jueves' },
+  { key: 'friday', label: 'Viernes' },
+  { key: 'saturday', label: 'Sábado' },
+  { key: 'sunday', label: 'Domingo' },
+];
+
+export const DAY_NUMBER_TO_KEY = DAYS.reduce((acc, day, index) => {
+  acc[index + 1] = day.key;
+  return acc;
+}, {});
+
+export const DAY_KEY_TO_NUMBER = DAYS.reduce((acc, day, index) => {
+  acc[day.key] = index + 1;
+  return acc;
+}, {});
+
+export const STATUS_LABELS = {
+  profile: 'Perfil',
+  schedule: 'Horarios',
+  services: 'Servicios',
+  taxes: 'Impuestos',
+};
+
+export const parseMaybeNumber = (value) => {
+  if (value === null || value === undefined || value === '') return null;
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+};
+
+let clientIdCounter = 0;
+export const createClientId = () => {
+  clientIdCounter += 1;
+  return `tmp-${Date.now()}-${clientIdCounter}`;
+};
+
+export const createEmptySchedule = () =>
+  DAYS.reduce((acc, day) => {
+    acc[day.key] = { enabled: false, ranges: [] };
+    return acc;
+  }, {});
+
+export const normalizeCatalogServices = (items) => {
+  if (!Array.isArray(items)) return [];
+  return items
+    .map((item) => {
+      const id = item?.id ?? item?.value ?? item?.key ?? item?.servicio_id ?? item?.codigo;
+      if (id === null || id === undefined) return null;
+      return {
+        id: String(id),
+        nombre: item?.nombre ?? item?.name ?? 'Servicio sin nombre',
+        descripcion: item?.descripcion ?? item?.description ?? '',
+      };
+    })
+    .filter(Boolean);
+};
+
+export const normalizeServices = (services) => {
+  if (!Array.isArray(services)) return [];
+  return services
+    .map((service) => {
+      if (service === null || service === undefined) return null;
+      if (typeof service === 'object') {
+        if (service?.seleccionado === false) return null;
+        const id = service?.id ?? service?.servicio_id ?? service?.codigo ?? service?.value;
+        return id === null || id === undefined ? null : String(id);
+      }
+      return String(service);
+    })
+    .filter((value) => value !== null && value !== undefined && value !== '');
+};
+
+export const normalizeTaxes = (taxes) => {
+  if (!Array.isArray(taxes)) return [];
+  return taxes.map((tax, index) => ({
+    id: tax?.id ?? tax?.impuesto_id ?? `tmp-${index}-${Date.now()}`,
+    nombre: tax?.nombre ?? tax?.name ?? '',
+    porcentaje:
+      tax?.porcentaje !== undefined && tax?.porcentaje !== null
+        ? String(tax.porcentaje)
+        : '',
+  }));
+};
+
+export const extractRanges = (ranges) => {
+  if (!Array.isArray(ranges)) return [];
+  return ranges
+    .map((range) => {
+      const start = range?.desde ?? range?.inicio ?? range?.start ?? range?.from ?? '';
+      const end = range?.hasta ?? range?.fin ?? range?.end ?? range?.to ?? '';
+      if (!start || !end) return null;
+      return { start, end };
+    })
+    .filter(Boolean);
+};
+
+export const normalizeSchedule = (schedule) => {
+  const base = createEmptySchedule();
+  if (!Array.isArray(schedule)) return base;
+  schedule.forEach((entry) => {
+    let normalizedKey;
+
+    const dayNumber =
+      entry?.dia_semana ?? entry?.dia_num ?? entry?.diaNumero ?? entry?.numero ?? null;
+    if (dayNumber !== null && dayNumber !== undefined) {
+      const numeric = Number(dayNumber);
+      if (Number.isInteger(numeric) && numeric >= 1 && numeric <= 7) {
+        normalizedKey = DAY_NUMBER_TO_KEY[numeric];
+      }
+    }
+
+    if (!normalizedKey) {
+      const rawKey =
+        (typeof entry?.dia === 'string' && entry.dia) ||
+        (typeof entry?.day === 'string' && entry.day) ||
+        (typeof entry?.nombre === 'string' && entry.nombre) ||
+        entry?.key ||
+        entry?.id;
+      if (!rawKey) return;
+      const lowerKey = String(rawKey).toLowerCase();
+      if (!(lowerKey in base)) return;
+      normalizedKey = lowerKey;
+    }
+
+    const start = entry?.abre ?? entry?.desde ?? entry?.inicio ?? entry?.start ?? entry?.from;
+    const end = entry?.cierra ?? entry?.hasta ?? entry?.fin ?? entry?.end ?? entry?.to;
+
+    let ranges = [];
+    if (start && end) {
+      ranges = [{ start, end }];
+    } else {
+      ranges = extractRanges(entry?.horarios ?? entry?.rangos ?? entry?.slots);
+    }
+
+    base[normalizedKey] = {
+      enabled: entry?.activo ?? entry?.habilitado ?? entry?.enabled ?? ranges.length > 0,
+      ranges,
+    };
+  });
+  return base;
+};
+
+export const denormalizeSchedule = (schedule) => {
+  if (!schedule || typeof schedule !== 'object') return [];
+
+  return DAYS.map((day) => {
+    const value = schedule?.[day.key] ?? {};
+    const ranges = Array.isArray(value?.ranges) ? value.ranges : [];
+    const firstRange = ranges.find((range) => range?.start && range?.end) || null;
+    const hasValidRange = Boolean(firstRange);
+
+    return {
+      dia_semana: DAY_KEY_TO_NUMBER[day.key],
+      abre: hasValidRange ? firstRange.start : null,
+      cierra: hasValidRange ? firstRange.end : null,
+      activo: Boolean(value?.enabled) && hasValidRange,
+    };
+  }).filter((item) => item.abre && item.cierra);
+};
+
+export const sanitizeServicesForPayload = (services) => {
+  if (!Array.isArray(services)) return [];
+  return services
+    .map((item) => {
+      if (item === null || item === undefined) return null;
+      let value = item;
+      if (typeof value === 'object') {
+        const id = value?.id ?? value?.servicio_id ?? value?.codigo ?? value?.value;
+        if (id === null || id === undefined) return null;
+        value = id;
+      }
+      const numeric = Number(value);
+      if (Number.isFinite(numeric)) {
+        return numeric;
+      }
+      const str = String(value).trim();
+      return str ? str : null;
+    })
+    .filter((value) => value !== null);
+};
+
+export const initialSaveStatus = Object.keys(STATUS_LABELS).reduce((acc, key) => {
+  acc[key] = { state: 'idle', message: '' };
+  return acc;
+}, {});
+
+export const buildFormState = (source = {}, fallback = {}) => {
+  const servicios = normalizeServices(source?.servicios ?? fallback?.servicios ?? []);
+  const impuestos = normalizeTaxes(source?.impuestos ?? fallback?.impuestos ?? []);
+
+  const rawSchedule = source?.horarios ?? fallback?.horarios;
+  let horarios;
+  if (Array.isArray(rawSchedule)) {
+    horarios = normalizeSchedule(rawSchedule);
+  } else if (rawSchedule && typeof rawSchedule === 'object') {
+    horarios = rawSchedule;
+  } else {
+    horarios = createEmptySchedule();
+  }
+
+  return {
+    nombre: source?.nombre ?? fallback?.nombre ?? '',
+    descripcion: source?.descripcion ?? fallback?.descripcion ?? '',
+    foto_logo: source?.foto_logo ?? fallback?.foto_logo ?? '',
+    provincia_id: source?.provincia_id ?? fallback?.provincia_id ?? null,
+    localidad_id: source?.localidad_id ?? fallback?.localidad_id ?? null,
+    localidad_nombre:
+      source?.localidad_nombre ?? source?.localidad?.nombre ?? fallback?.localidad_nombre ?? '',
+    telefono_contacto: source?.telefono_contacto ?? fallback?.telefono_contacto ?? '',
+    email_contacto: source?.email_contacto ?? fallback?.email_contacto ?? '',
+    direccion: source?.direccion ?? fallback?.direccion ?? '',
+    latitud: parseMaybeNumber(source?.latitud ?? fallback?.latitud ?? null),
+    longitud: parseMaybeNumber(source?.longitud ?? fallback?.longitud ?? null),
+    google_place_id: source?.google_place_id ?? fallback?.google_place_id ?? '',
+    servicios,
+    impuestos,
+    horarios,
+  };
+};


### PR DESCRIPTION
## Summary
- pass the raw schedule payload into `buildFormState` and share the configuration helpers
- update `buildFormState` to reuse normalized schedule objects without reprocessing
- add a node-based test covering the save/reload visibility of configured schedules

## Testing
- node --test meClub/src/screens/dashboard/__tests__/configurationState.test.js

------
https://chatgpt.com/codex/tasks/task_e_68df2070c950832fa9c5007cc1ddcf80