### PR TITLE
Light- 0.1.21025.2215

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@
 ## Resumen de club
 
 meClub App
+
+## Configuración de Google Maps
+
+Para habilitar el mapa web necesitás exponer tu clave de Google Maps como una variable de entorno accesible para Expo:
+
+```bash
+export EXPO_PUBLIC_GOOGLE_MAPS_API_KEY="tu_clave_de_maps"
+```
+
+Al iniciar la aplicación con esa variable definida, el mapa mostrará la ubicación actual y permitirá arrastrar el marcador o hacer clic para seleccionar nuevas coordenadas.

--- a/meClub/package.json
+++ b/meClub/package.json
@@ -14,6 +14,7 @@
     "@expo/metro-runtime": "~5.0.4",
     "@expo/vector-icons": "^14.1.0",
     "@hookform/resolvers": "^5.2.1",
+    "@react-google-maps/api": "^2.20.7",
     "@react-native-async-storage/async-storage": "2.1.2",
     "@react-navigation/drawer": "^7.5.6",
     "@react-navigation/native": "^7.1.17",


### PR DESCRIPTION
## Summary
- install the @react-google-maps/api wrapper in the Expo web app and document the EXPO_PUBLIC_GOOGLE_MAPS_API_KEY variable
- replace the web map placeholder with an interactive Google Map that supports clicks and draggable markers
- preserve manual coordinate entry and current location shortcuts while keeping reverse geocoding updates working

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df21bc76f8832f93907a221b4e64a6