### PR TITLE
Light- 0.1.31025.1423

### DIFF
--- a/meClub/src/components/MapPicker.web.jsx
+++ b/meClub/src/components/MapPicker.web.jsx
@@ -4,6 +4,8 @@ import { ActivityIndicator, Pressable, Text, TextInput, View, Platform } from 'r
 import * as Location from 'expo-location';
 import { GoogleMap, useJsApiLoader } from '@react-google-maps/api';
 
+const GOOGLE_MAP_LIBRARIES = ['marker'];
+
 const buildPlaceId = (coordinate, address) => {
   if (!coordinate) return null;
   if (address?.name && address?.isoCountryCode) {
@@ -41,7 +43,7 @@ export default function MapPicker({
   const { isLoaded, loadError } = useJsApiLoader({
     id: 'google-maps-script',
     googleMapsApiKey: googleMapsApiKey ?? '',
-    libraries: ['marker'],
+    libraries: GOOGLE_MAP_LIBRARIES,
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- declare a reusable constant with the Google Maps API libraries required by the web MapPicker
- reference the new constant when configuring `useJsApiLoader`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e005f4cd78832fae7225e760542714