### PR TITLE
Light- 0.1.31025.1430

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Para habilitar el mapa web necesitás exponer tu clave de Google Maps como una v
 
 ```bash
 export EXPO_PUBLIC_GOOGLE_MAPS_API_KEY="tu_clave_de_maps"
+export EXPO_PUBLIC_GOOGLE_MAPS_MAP_ID="tu_map_id_de_maps"
 ```
 
-Al iniciar la aplicación con esa variable definida, el mapa mostrará la ubicación actual y permitirá arrastrar el marcador o hacer clic para seleccionar nuevas coordenadas.
+Podés agregar estas variables en un archivo `.env` ubicado en la raíz del proyecto para que Expo las cargue automáticamente.
+
+Al iniciar la aplicación con esas variables definidas, el mapa mostrará la ubicación actual y permitirá arrastrar el marcador o hacer clic para seleccionar nuevas coordenadas. Con el `EXPO_PUBLIC_GOOGLE_MAPS_MAP_ID` configurado, la aplicación utilizará los **Advanced Markers**; si omitís esa variable se mostrará el marcador clásico automáticamente.


### PR DESCRIPTION
## Summary
- document the new EXPO_PUBLIC_GOOGLE_MAPS_MAP_ID variable required to enable Google Maps advanced markers
- pass the configured mapId to the web map picker and fall back to the classic marker when advanced markers are unavailable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e006b19590832fa456493bf1a3324d