### PR TITLE
Light- 0.2.31025.1635

### DIFF
--- a/meClub/src/components/MapPicker.native.jsx
+++ b/meClub/src/components/MapPicker.native.jsx
@@ -31,6 +31,7 @@ export default function MapPicker({
   googlePlaceId,
   onChange,
   style,
+  children,
 }) {
   const mapRef = useRef(null);
   const [isRequestingLocation, setIsRequestingLocation] = useState(false);
@@ -120,6 +121,7 @@ export default function MapPicker({
           {hasCoordinate && <Marker coordinate={{ latitude, longitude }} />}
         </MapView>
       </View>
+      {children}
       <View className="flex-row flex-wrap items-center justify-between gap-3">
         <View>
           <Text className="text-white/70 text-xs uppercase tracking-[0.2em]">Ubicación seleccionada</Text>

--- a/meClub/src/components/MapPicker.web.jsx
+++ b/meClub/src/components/MapPicker.web.jsx
@@ -25,6 +25,7 @@ export default function MapPicker({
   googlePlaceId,
   onChange,
   style,
+  children,
 }) {
   const [isRequestingLocation, setIsRequestingLocation] = useState(false);
   const [mapError, setMapError] = useState('');
@@ -170,8 +171,8 @@ export default function MapPicker({
   }, [emitChange, pendingLatitude, pendingLongitude]);
 
   return (
-    <View style={style} className="gap-3">
-      <View className="h-64 w-full overflow-hidden rounded-3xl border border-white/10 bg-black/20">
+    <View style={style} className="flex flex-col gap-4 lg:flex-row">
+      <View className="h-64 w-full overflow-hidden rounded-3xl border border-white/10 bg-black/20 lg:w-1/2">
         {mapLoadError || !googleMapsApiKey ? (
           <View className="flex-1 items-center justify-center gap-3 px-6 text-center">
             <Text className="text-white/70 text-sm font-medium">Mapa interactivo no disponible en este momento</Text>
@@ -204,59 +205,62 @@ export default function MapPicker({
           </GoogleMap>
         )}
       </View>
-      <View className="flex-row flex-wrap items-center justify-between gap-3">
-        <View className="gap-2">
-          <Text className="text-white/70 text-xs uppercase tracking-[0.2em]">Ubicación seleccionada</Text>
-          <View className="flex-row flex-wrap gap-2">
-            <View className="flex-1 min-w-[120px]">
-              <Text className="text-white/50 text-[11px]">Latitud</Text>
-              <TextInput
-                value={pendingLatitude}
-                onChangeText={setPendingLatitude}
-                keyboardType="numeric"
-                placeholder="-34.6037"
-                placeholderTextColor="rgba(255,255,255,0.3)"
-                className="rounded-2xl border border-white/10 bg-black/20 px-3 py-2 text-white"
-              />
+      <View className="flex w-full flex-col gap-4 lg:w-1/2">
+        {children}
+        <View className="flex flex-col gap-3 rounded-3xl border border-white/10 bg-black/20 p-4">
+          <View className="gap-2">
+            <Text className="text-white/70 text-xs uppercase tracking-[0.2em]">Ubicación seleccionada</Text>
+            <View className="flex flex-col gap-2">
+              <View className="flex flex-col gap-1">
+                <Text className="text-white/50 text-[11px]">Latitud</Text>
+                <TextInput
+                  value={pendingLatitude}
+                  onChangeText={setPendingLatitude}
+                  keyboardType="numeric"
+                  placeholder="-34.6037"
+                  placeholderTextColor="rgba(255,255,255,0.3)"
+                  className="rounded-2xl border border-white/10 bg-black/40 px-3 py-2 text-white"
+                />
+              </View>
+              <View className="flex flex-col gap-1">
+                <Text className="text-white/50 text-[11px]">Longitud</Text>
+                <TextInput
+                  value={pendingLongitude}
+                  onChangeText={setPendingLongitude}
+                  keyboardType="numeric"
+                  placeholder="-58.3816"
+                  placeholderTextColor="rgba(255,255,255,0.3)"
+                  className="rounded-2xl border border-white/10 bg-black/40 px-3 py-2 text-white"
+                />
+              </View>
             </View>
-            <View className="flex-1 min-w-[120px]">
-              <Text className="text-white/50 text-[11px]">Longitud</Text>
-              <TextInput
-                value={pendingLongitude}
-                onChangeText={setPendingLongitude}
-                keyboardType="numeric"
-                placeholder="-58.3816"
-                placeholderTextColor="rgba(255,255,255,0.3)"
-                className="rounded-2xl border border-white/10 bg-black/20 px-3 py-2 text-white"
-              />
-            </View>
+            {hasCoordinate ? (
+              <Text className="text-white/40 text-[11px]">Google place: {googlePlaceId ?? 'Sin información adicional'}</Text>
+            ) : (
+              <Text className="text-white/60 text-sm">Elegí un punto con los controles disponibles</Text>
+            )}
           </View>
-          {hasCoordinate ? (
-            <Text className="text-white/40 text-[11px]">Google place: {googlePlaceId ?? 'Sin información adicional'}</Text>
-          ) : (
-            <Text className="text-white/60 text-sm">Elegí un punto con los controles disponibles</Text>
-          )}
+          <View className="flex flex-col gap-2">
+            <Pressable
+              onPress={handleApplyManualCoordinates}
+              className="rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-center hover:bg-white/10"
+            >
+              <Text className="text-white/80 text-sm font-medium">Aplicar coordenadas</Text>
+            </Pressable>
+            <Pressable
+              onPress={handleSelectCurrentLocation}
+              disabled={isRequestingLocation}
+              className={`flex-row items-center justify-center gap-2 rounded-2xl border border-white/10 px-4 py-2 ${
+                isRequestingLocation ? 'bg-white/10' : 'bg-white/5 hover:bg-white/10'
+              }`}
+            >
+              {isRequestingLocation && <ActivityIndicator color="#F59E0B" />}
+              <Text className="text-white/80 text-sm font-medium">Usar mi ubicación actual</Text>
+            </Pressable>
+          </View>
         </View>
-        <View className="gap-2">
-          <Pressable
-            onPress={handleApplyManualCoordinates}
-            className="rounded-2xl border border-white/10 bg-white/5 px-4 py-2 hover:bg-white/10"
-          >
-            <Text className="text-white/80 text-sm font-medium">Aplicar coordenadas</Text>
-          </Pressable>
-          <Pressable
-            onPress={handleSelectCurrentLocation}
-            disabled={isRequestingLocation}
-            className={`flex-row items-center justify-center gap-2 rounded-2xl border border-white/10 px-4 py-2 ${
-              isRequestingLocation ? 'bg-white/10' : 'bg-white/5 hover:bg-white/10'
-            }`}
-          >
-            {isRequestingLocation && <ActivityIndicator color="#F59E0B" />}
-            <Text className="text-white/80 text-sm font-medium">Usar mi ubicación actual</Text>
-          </Pressable>
-        </View>
+        {!!mapError && <Text className="text-red-300 text-xs">{mapError}</Text>}
       </View>
-      {!!mapError && <Text className="text-red-300 text-xs">{mapError}</Text>}
     </View>
   );
 }

--- a/meClub/src/screens/dashboard/configurationState.js
+++ b/meClub/src/screens/dashboard/configurationState.js
@@ -187,6 +187,36 @@ export const initialSaveStatus = Object.keys(STATUS_LABELS).reduce((acc, key) =>
   return acc;
 }, {});
 
+export const splitAddress = (value) => {
+  if (typeof value !== 'string') {
+    return { street: '', number: '' };
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return { street: '', number: '' };
+  }
+
+  const parts = trimmed.split(/\s+/);
+  const last = parts[parts.length - 1];
+  if (last && /\d/.test(last)) {
+    return {
+      street: parts.slice(0, -1).join(' ').trim(),
+      number: last.trim(),
+    };
+  }
+
+  return { street: trimmed, number: '' };
+};
+
+export const composeAddress = (street, number) => {
+  const safeStreet = typeof street === 'string' ? street.trim() : '';
+  const safeNumber = typeof number === 'string' ? number.trim() : '';
+  if (safeStreet && safeNumber) {
+    return `${safeStreet} ${safeNumber}`;
+  }
+  return safeStreet || safeNumber || '';
+};
+
 export const buildFormState = (source = {}, fallback = {}) => {
   const servicios = normalizeServices(source?.servicios ?? fallback?.servicios ?? []);
   const impuestos = normalizeTaxes(source?.impuestos ?? fallback?.impuestos ?? []);
@@ -201,6 +231,9 @@ export const buildFormState = (source = {}, fallback = {}) => {
     horarios = createEmptySchedule();
   }
 
+  const direccion = source?.direccion ?? fallback?.direccion ?? '';
+  const { street: direccion_calle, number: direccion_numero } = splitAddress(direccion);
+
   return {
     nombre: source?.nombre ?? fallback?.nombre ?? '',
     descripcion: source?.descripcion ?? fallback?.descripcion ?? '',
@@ -211,7 +244,9 @@ export const buildFormState = (source = {}, fallback = {}) => {
       source?.localidad_nombre ?? source?.localidad?.nombre ?? fallback?.localidad_nombre ?? '',
     telefono_contacto: source?.telefono_contacto ?? fallback?.telefono_contacto ?? '',
     email_contacto: source?.email_contacto ?? fallback?.email_contacto ?? '',
-    direccion: source?.direccion ?? fallback?.direccion ?? '',
+    direccion,
+    direccion_calle,
+    direccion_numero,
     latitud: parseMaybeNumber(source?.latitud ?? fallback?.latitud ?? null),
     longitud: parseMaybeNumber(source?.longitud ?? fallback?.longitud ?? null),
     google_place_id: source?.google_place_id ?? fallback?.google_place_id ?? '',


### PR DESCRIPTION
## Summary
- restructure the web map picker into a responsive 50/50 layout with a children slot and column-based controls
- allow the native map picker to render extra content below the map
- split address information into street and number fields across configuration state and persistence logic

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e023248764832fa6514c6538a3f3c0