### PR TITLE
Light- 0.2.31025.1755

### DIFF
--- a/meClub/src/components/MapPicker.web.jsx
+++ b/meClub/src/components/MapPicker.web.jsx
@@ -226,10 +226,10 @@ export default function MapPicker({
         </View>
         {!!mapError && <Text className="px-4 pb-4 text-red-300 text-xs">{mapError}</Text>}
       </View>
-      <View className="flex w-full flex-col gap-4 lg:w-1/2">
-        {children}
-        <View className="flex flex-col gap-3 rounded-3xl border border-white/10 bg-black/20 p-4">
-          <View className="gap-2">
+      <View className="flex w-full flex-col lg:w-1/2">
+        <View className="flex flex-col gap-4 rounded-3xl border border-white/10 bg-black/20 p-4">
+          {children}
+          <View className="flex flex-col gap-2">
             <Text className="text-white/70 text-xs uppercase tracking-[0.2em]">Ubicación seleccionada</Text>
             <View className="flex flex-col gap-2">
               <View className="flex flex-col gap-1">

--- a/meClub/src/screens/dashboard/ConfiguracionScreen.jsx
+++ b/meClub/src/screens/dashboard/ConfiguracionScreen.jsx
@@ -737,7 +737,7 @@ export default function ConfiguracionScreen({ go }) {
               onChange={handleMapChange}
               style={{ marginTop: 16 }}
             >
-              <View className="flex flex-col gap-3 rounded-3xl border border-white/10 bg-black/20 p-4">
+              <View className="flex flex-col gap-3">
                 <Text className="text-white/70 text-xs uppercase tracking-[0.2em]">Dirección</Text>
                 <View className="flex flex-col gap-3">
                   <View className="flex flex-col gap-2">


### PR DESCRIPTION
## Summary
- combine the MapPicker address content and selected location details into a single card on web
- update the configuration screen to pass unwrapped address fields to the MapPicker card

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e035ef51e0832f86b49ae932fece63