### PR TITLE
Add economia dashboard screen and navigation

### DIFF
--- a/meClub/src/screens/DashboardShell.jsx
+++ b/meClub/src/screens/DashboardShell.jsx
@@ -5,7 +5,13 @@ import { Ionicons } from '@expo/vector-icons';
 import { colors as mcColors } from '../theme/tokens';
 import { useAuth } from '../features/auth/useAuth';
 import { getClubSummary } from '../lib/api';
-import { InicioScreen, ReservasScreen, CanchasScreen, ConfiguracionScreen } from './dashboard';
+import {
+  InicioScreen,
+  ReservasScreen,
+  CanchasScreen,
+  ConfiguracionScreen,
+  EconomiaScreen,
+} from './dashboard';
 
 const NAV_BG = 'bg-[#0F172A]/80';
 
@@ -89,13 +95,12 @@ export default function DashboardShell() {
     { key: 'buzon', label: 'Buzón', iconName: 'mail-outline' },
     { key: 'mis-canchas', label: 'Mis Canchas', iconName: 'tennisball-outline' },
     { key: 'reservas', label: 'Reservas', iconName: 'calendar-outline' },
-    { key: 'horarios', label: 'Horarios', iconName: 'time-outline' },
+    { key: 'economia', label: 'Economía', iconName: 'cash-outline' },
     { key: 'tarifas', label: 'Tarifas', iconName: 'pricetags-outline' },
     { key: 'grabaciones', label: 'Grabaciones', iconName: 'videocam-outline' },
     { key: 'eventos', label: 'Eventos', iconName: 'sparkles-outline' },
     { key: 'me-equipo', label: 'meEquipo', iconName: 'people-outline' },
     { key: 'ranking', label: 'Ranking', iconName: 'trophy-outline' },
-    { key: 'conciliar', label: 'Conciliar', iconName: 'repeat-outline' },
     { key: 'configuracion', label: 'Configuración', iconName: 'settings-outline' },
     { key: 'soporte', label: 'Soporte', iconName: 'help-circle-outline' },
   ];
@@ -143,6 +148,7 @@ export default function DashboardShell() {
     reservas: ReservasScreen,
     'mis-canchas': CanchasScreen,
     configuracion: ConfiguracionScreen,
+    economia: EconomiaScreen,
   };
   const ScreenComponent = screenMap[activeKey] || (() => null);
   const screenProps = { summary, firstName, today, go };

--- a/meClub/src/screens/dashboard/EconomiaScreen.jsx
+++ b/meClub/src/screens/dashboard/EconomiaScreen.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function EconomiaScreen({ summary = {} }) {
+  const formattedAmount = React.useMemo(
+    () => `$${Number(summary.economiaMes ?? 0).toLocaleString('es-AR')}`,
+    [summary.economiaMes],
+  );
+
+  return (
+    <View className="flex-1">
+      <View className="py-6">
+        <Text className="text-white text-[36px] font-extrabold tracking-tight">Economía</Text>
+        <Text className="text-white/60 mt-1">Resumen económico del club</Text>
+      </View>
+      <View className="gap-6">
+        <View className="rounded-3xl border border-white/10 bg-white/5 p-6">
+          <Text className="text-white/70 text-[14px] uppercase tracking-[0.2em]">
+            Ingresos del mes
+          </Text>
+          <Text className="text-white text-[40px] font-extrabold mt-3">{formattedAmount}</Text>
+          <Text className="text-white/50 mt-2">
+            Mantén al día tus registros económicos y controla la salud financiera del club.
+          </Text>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/meClub/src/screens/dashboard/index.js
+++ b/meClub/src/screens/dashboard/index.js
@@ -2,3 +2,4 @@ export { default as InicioScreen } from './InicioScreen';
 export { default as CanchasScreen } from './CanchasScreen';
 export { default as ReservasScreen } from './ReservasScreen';
 export { default as ConfiguracionScreen } from './ConfiguracionScreen';
+export { default as EconomiaScreen } from './EconomiaScreen';


### PR DESCRIPTION
## Summary
- replace the Horarios sidebar entry with Economía and remove Conciliar
- wire the new economía route to a dedicated screen component
- add an Economía dashboard screen with a basic monthly income summary view

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e512be4854832f85a9954b51ec7baa