### PR TITLE
Light- 0.3.71025.1333

### DIFF
--- a/backend/models/canchas.model.js
+++ b/backend/models/canchas.model.js
@@ -1,22 +1,139 @@
+const fs = require('fs');
+const path = require('path');
+const { randomUUID } = require('crypto');
+
 const db = require('../config/db');
+const ReservasModel = require('./reservas.model');
+
+const imagenesDir = path.join(__dirname, '..', 'uploads', 'canchas');
+const imagenesPublicPath = '/uploads/canchas';
+
+fs.mkdirSync(imagenesDir, { recursive: true });
+
+const ESTADOS_VALIDOS = new Set(['disponible', 'mantenimiento', 'inactiva']);
+
+const mapCanchaRow = (row) => {
+  if (!row) return null;
+
+  const normalizeDecimal = (value) => {
+    if (value === null || value === undefined) return null;
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : null;
+  };
+
+  const normalizeInteger = (value) => {
+    if (value === null || value === undefined) return null;
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : null;
+  };
+
+  const normalizeString = (value) => {
+    if (value === null || value === undefined) return null;
+    if (typeof value === 'string') return value;
+    if (Buffer.isBuffer(value)) {
+      const candidate = value.toString('utf8').trim();
+      return candidate || null;
+    }
+    return String(value);
+  };
+
+  return {
+    ...row,
+    precio: normalizeDecimal(row.precio),
+    precio_dia: normalizeDecimal(row.precio_dia),
+    precio_noche: normalizeDecimal(row.precio_noche),
+    capacidad: normalizeInteger(row.capacidad),
+    techada: !!row.techada,
+    iluminacion: !!row.iluminacion,
+    tipo_suelo: normalizeString(row.tipo_suelo),
+    estado: typeof row.estado === 'string' ? row.estado : 'disponible',
+    imagen_url: normalizeString(row.imagen_url),
+  };
+};
+
+const obtenerExtensionDesdeMime = (mimetype = '', originalname = '') => {
+  if (typeof mimetype === 'string') {
+    if (mimetype.includes('png')) return '.png';
+    if (mimetype.includes('jpeg') || mimetype.includes('jpg')) return '.jpg';
+    if (mimetype.includes('webp')) return '.webp';
+  }
+  const ext = path.extname(originalname || '').toLowerCase();
+  if (ext) return ext;
+  return '.png';
+};
+
+const escribirImagen = async (buffer, mimetype, originalname) => {
+  if (!Buffer.isBuffer(buffer) || buffer.length === 0) {
+    throw new Error('Buffer de imagen inválido');
+  }
+
+  const extension = obtenerExtensionDesdeMime(mimetype, originalname);
+  const filename = `${Date.now()}-${randomUUID()}${extension}`;
+  const absolutePath = path.join(imagenesDir, filename);
+  await fs.promises.writeFile(absolutePath, buffer);
+  return path.posix.join(imagenesPublicPath, filename);
+};
+
+const eliminarImagen = async (storedPath) => {
+  if (!storedPath) return;
+  if (storedPath.startsWith('http')) return;
+  const normalized = storedPath.split('?')[0];
+  if (!normalized.startsWith(imagenesPublicPath)) return;
+  const filename = path.posix.basename(normalized);
+  const absolutePath = path.join(imagenesDir, filename);
+  try {
+    await fs.promises.unlink(absolutePath);
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      console.error('Error eliminando imagen de cancha', absolutePath, err);
+    }
+  }
+};
 
 const CanchasModel = {
-  crearCancha: async ({ club_id, nombre, deporte_id, capacidad, precio, techada = 0, iluminacion = 0 }) => {
+  crearCancha: async ({
+    club_id,
+    nombre,
+    deporte_id,
+    capacidad = null,
+    precio = null,
+    precio_dia = null,
+    precio_noche = null,
+    tipo_suelo = null,
+    techada = 0,
+    iluminacion = 0,
+    estado = 'disponible',
+    imagen_url = null,
+  }) => {
+    const estadoNormalizado = ESTADOS_VALIDOS.has(estado) ? estado : 'disponible';
+
     const [result] = await db.query(
-      `INSERT INTO canchas (club_id, nombre, deporte_id, capacidad, precio, techada, iluminacion)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
-      [club_id, nombre, deporte_id, capacidad, precio, techada ? 1 : 0, iluminacion ? 1 : 0]
+      `INSERT INTO canchas
+       (club_id, nombre, deporte_id, capacidad, precio, precio_dia, precio_noche, tipo_suelo, techada, iluminacion, estado, imagen_url)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        club_id,
+        nombre,
+        deporte_id,
+        capacidad === undefined ? null : capacidad,
+        precio === undefined ? null : precio,
+        precio_dia === undefined ? null : precio_dia,
+        precio_noche === undefined ? null : precio_noche,
+        tipo_suelo === undefined ? null : tipo_suelo,
+        techada ? 1 : 0,
+        iluminacion ? 1 : 0,
+        estadoNormalizado,
+        imagen_url === undefined ? null : imagen_url,
+      ]
     );
-    return {
-      cancha_id: result.insertId,
-      club_id, nombre, deporte_id, capacidad, precio,
-      techada: !!techada, iluminacion: !!iluminacion
-    };
+
+    const creada = await CanchasModel.obtenerCanchaPorId(result.insertId);
+    return creada;
   },
 
   obtenerCanchaPorId: async (cancha_id) => {
     const [rows] = await db.query(`SELECT * FROM canchas WHERE cancha_id = ?`, [cancha_id]);
-    return rows[0] || null;
+    return mapCanchaRow(rows[0] || null);
   },
 
   perteneceAClub: async (cancha_id, club_id) => {
@@ -29,15 +146,172 @@ const CanchasModel = {
 
   listarPorClub: async (club_id) => {
     const [rows] = await db.query(
-      `SELECT cancha_id, nombre, deporte_id, capacidad, precio, techada, iluminacion
+      `SELECT cancha_id, club_id, nombre, deporte_id, capacidad, precio, precio_dia, precio_noche,
+              tipo_suelo, techada, iluminacion, estado, imagen_url
        FROM canchas
        WHERE club_id = ?
        ORDER BY cancha_id DESC`,
       [club_id]
     );
-    return rows;
+    return rows.map(mapCanchaRow);
+  },
+
+  actualizarCancha: async (
+    cancha_id,
+    {
+      nombre,
+      deporte_id,
+      capacidad,
+      precio,
+      precio_dia,
+      precio_noche,
+      tipo_suelo,
+      techada,
+      iluminacion,
+      estado,
+      imagen_url,
+    } = {}
+  ) => {
+    const existente = await CanchasModel.obtenerCanchaPorId(cancha_id);
+    if (!existente) {
+      throw new Error('Cancha no encontrada');
+    }
+
+    const updates = [];
+    const values = [];
+
+    const setNullable = (field, value) => {
+      if (value === undefined) return;
+      if (value === null) {
+        updates.push(`${field} = NULL`);
+      } else {
+        updates.push(`${field} = ?`);
+        values.push(value);
+      }
+    };
+
+    if (nombre !== undefined) {
+      setNullable('nombre', nombre === null ? null : String(nombre));
+    }
+    if (deporte_id !== undefined) {
+      updates.push('deporte_id = ?');
+      values.push(deporte_id);
+    }
+    setNullable('capacidad', capacidad === undefined ? undefined : capacidad);
+    setNullable('precio', precio === undefined ? undefined : precio);
+    setNullable('precio_dia', precio_dia === undefined ? undefined : precio_dia);
+    setNullable('precio_noche', precio_noche === undefined ? undefined : precio_noche);
+    setNullable('tipo_suelo', tipo_suelo === undefined ? undefined : tipo_suelo);
+
+    if (techada !== undefined) {
+      updates.push('techada = ?');
+      values.push(techada ? 1 : 0);
+    }
+
+    if (iluminacion !== undefined) {
+      updates.push('iluminacion = ?');
+      values.push(iluminacion ? 1 : 0);
+    }
+
+    if (estado !== undefined) {
+      const estadoNormalizado = ESTADOS_VALIDOS.has(estado) ? estado : 'disponible';
+      updates.push('estado = ?');
+      values.push(estadoNormalizado);
+    }
+
+    if (imagen_url !== undefined) {
+      setNullable('imagen_url', imagen_url);
+    }
+
+    if (updates.length === 0) {
+      return existente;
+    }
+
+    const sql = `UPDATE canchas SET ${updates.join(', ')} WHERE cancha_id = ?`;
+    values.push(cancha_id);
+    await db.query(sql, values);
+
+    return CanchasModel.obtenerCanchaPorId(cancha_id);
+  },
+
+  eliminarCancha: async (cancha_id) => {
+    const existente = await CanchasModel.obtenerCanchaPorId(cancha_id);
+    if (!existente) {
+      return false;
+    }
+
+    await db.query(`DELETE FROM canchas WHERE cancha_id = ?`, [cancha_id]);
+    if (existente.imagen_url) {
+      await eliminarImagen(existente.imagen_url);
+    }
+    return true;
+  },
+
+  guardarImagen: async (cancha_id, file) => {
+    if (!file || !Buffer.isBuffer(file.buffer) || file.buffer.length === 0) {
+      throw new Error('Archivo de imagen inválido');
+    }
+
+    const storedPath = await escribirImagen(file.buffer, file.mimetype, file.originalname);
+    await db.query(`UPDATE canchas SET imagen_url = ? WHERE cancha_id = ?`, [storedPath, cancha_id]);
+    return storedPath;
+  },
+
+  actualizarImagen: async (cancha_id, file) => {
+    const existente = await CanchasModel.obtenerCanchaPorId(cancha_id);
+    if (!existente) {
+      throw new Error('Cancha no encontrada');
+    }
+
+    const storedPath = await CanchasModel.guardarImagen(cancha_id, file);
+    if (existente.imagen_url && existente.imagen_url !== storedPath) {
+      await eliminarImagen(existente.imagen_url);
+    }
+    return storedPath;
+  },
+
+  obtenerResumen: async (cancha_id) => {
+    const cancha = await CanchasModel.obtenerCanchaPorId(cancha_id);
+    if (!cancha) {
+      return null;
+    }
+
+    const hoy = new Date();
+    const hoyStr = hoy.toISOString().slice(0, 10);
+    const reservasHoy = await ReservasModel.reservasPorCanchaFecha(cancha_id, hoyStr);
+
+    const ahora = hoy.getTime();
+    const ocupadaAhora = reservasHoy.some((reserva) => {
+      const inicio = new Date(`${reserva.fecha}T${reserva.hora_inicio}`);
+      const fin = new Date(`${reserva.fecha}T${reserva.hora_fin}`);
+      return inicio.getTime() <= ahora && fin.getTime() > ahora;
+    });
+
+    const [proximasRows] = await db.query(
+      `SELECT r.reserva_id, r.fecha, r.hora_inicio, r.hora_fin, r.estado
+       FROM reservas r
+       WHERE r.cancha_id = ?
+         AND (r.fecha > CURDATE() OR (r.fecha = CURDATE() AND r.hora_inicio >= DATE_FORMAT(NOW(), '%H:%i:%s')))
+       ORDER BY r.fecha ASC, r.hora_inicio ASC
+       LIMIT 5`,
+      [cancha_id]
+    );
+
+    return {
+      cancha,
+      estado: cancha.estado,
+      disponibleAhora: cancha.estado === 'disponible' && !ocupadaAhora,
+      enMantenimiento: cancha.estado === 'mantenimiento',
+      inactiva: cancha.estado === 'inactiva',
+      reservasHoy,
+      proximasReservas: proximasRows,
+      proximaReserva: proximasRows && proximasRows.length > 0 ? proximasRows[0] : null,
+    };
   },
 };
+
+CanchasModel._mapCanchaRow = mapCanchaRow;
+CanchasModel._imagenes = { dir: imagenesDir, publicPath: imagenesPublicPath };
 
 module.exports = CanchasModel;
 

--- a/backend/models/clubes.model.js
+++ b/backend/models/clubes.model.js
@@ -142,10 +142,34 @@ const ClubesModel = {
 
   obtenerMisCanchas: async (club_id) => {
     const [rows] = await db.query(
-      'SELECT * FROM canchas WHERE club_id = ? ORDER BY cancha_id DESC',
+      `SELECT c.cancha_id, c.club_id, c.nombre, c.deporte_id, c.capacidad, c.precio, c.precio_dia,
+              c.precio_noche, c.tipo_suelo, c.techada, c.iluminacion, c.estado, c.imagen_url,
+              d.nombre AS deporte_nombre
+       FROM canchas c
+       LEFT JOIN deportes d ON d.deporte_id = c.deporte_id
+       WHERE c.club_id = ?
+       ORDER BY c.cancha_id DESC`,
       [club_id]
     );
-    return rows;
+
+    return rows.map((row) => ({
+      cancha_id: row.cancha_id,
+      club_id: row.club_id,
+      nombre: row.nombre,
+      deporte_id: row.deporte_id,
+      deporte_nombre: row.deporte_nombre || null,
+      capacidad: row.capacidad === null || row.capacidad === undefined ? null : Number(row.capacidad),
+      precio: row.precio === null || row.precio === undefined ? null : Number(row.precio),
+      precio_dia:
+        row.precio_dia === null || row.precio_dia === undefined ? null : Number(row.precio_dia),
+      precio_noche:
+        row.precio_noche === null || row.precio_noche === undefined ? null : Number(row.precio_noche),
+      tipo_suelo: row.tipo_suelo == null ? null : row.tipo_suelo,
+      techada: !!row.techada,
+      iluminacion: !!row.iluminacion,
+      estado: row.estado || 'disponible',
+      imagen_url: row.imagen_url == null ? null : row.imagen_url,
+    }));
   },
 
   obtenerClubPorId: async (club_id) => {

--- a/backend/tests/clubes.misCanchas.test.js
+++ b/backend/tests/clubes.misCanchas.test.js
@@ -1,0 +1,206 @@
+const express = require('express');
+const request = require('supertest');
+
+jest.mock('../middleware/auth.middleware', () => (req, _res, next) => next());
+jest.mock('../middleware/roles.middleware', () => ({
+  requireRole: () => (req, _res, next) => next(),
+}));
+jest.mock('../middleware/club.middleware', () => (req, _res, next) => {
+  req.club = { club_id: 10, nombre: 'Club Prueba' };
+  next();
+});
+
+global.__testCanchaFile = null;
+jest.mock('../middleware/logoUpload.middleware', () => ({
+  buildSingleUploadMiddleware: jest.fn(() => (req, _res, next) => {
+    if (global.__testCanchaFile) {
+      req.file = global.__testCanchaFile;
+    }
+    next();
+  }),
+}));
+
+jest.mock('../models/clubes.model', () => ({
+  obtenerMisCanchas: jest.fn(),
+}));
+
+jest.mock('../models/canchas.model', () => ({
+  crearCancha: jest.fn(),
+  obtenerCanchaPorId: jest.fn(),
+  actualizarCancha: jest.fn(),
+  eliminarCancha: jest.fn(),
+  actualizarImagen: jest.fn(),
+  obtenerResumen: jest.fn(),
+}));
+
+const ClubesModel = require('../models/clubes.model');
+const CanchasModel = require('../models/canchas.model');
+const { buildSingleUploadMiddleware } = require('../middleware/logoUpload.middleware');
+const clubesRoutes = require('../routes/clubes.routes');
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/', clubesRoutes);
+  return app;
+};
+
+describe('Rutas de Mis Canchas', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.__testCanchaFile = null;
+  });
+
+  it('lista canchas con campos extendidos', async () => {
+    const app = buildApp();
+    ClubesModel.obtenerMisCanchas.mockResolvedValue([
+      {
+        cancha_id: 1,
+        club_id: 10,
+        nombre: 'Central',
+        deporte_id: 2,
+        deporte_nombre: 'Fútbol 5',
+        capacidad: 10,
+        precio: 1500,
+        precio_dia: 1500,
+        precio_noche: 1700,
+        tipo_suelo: 'Césped',
+        techada: true,
+        iluminacion: true,
+        estado: 'disponible',
+        imagen_url: '/uploads/canchas/central.png',
+      },
+    ]);
+
+    const res = await request(app).get('/mis-canchas');
+
+    expect(res.status).toBe(200);
+    expect(res.body.canchas).toHaveLength(1);
+    expect(res.body.canchas[0]).toHaveProperty('deporte_nombre', 'Fútbol 5');
+    expect(ClubesModel.obtenerMisCanchas).toHaveBeenCalledWith(10);
+  });
+
+  it('rechaza creación sin campos obligatorios', async () => {
+    const app = buildApp();
+
+    const res = await request(app).post('/mis-canchas').send({ nombre: '' });
+
+    expect(res.status).toBe(400);
+    expect(CanchasModel.crearCancha).not.toHaveBeenCalled();
+  });
+
+  it('crea cancha con normalización de datos', async () => {
+    const app = buildApp();
+
+    CanchasModel.crearCancha.mockResolvedValue({ cancha_id: 55 });
+
+    const res = await request(app)
+      .post('/mis-canchas')
+      .send({
+        nombre: '  Cancha Central  ',
+        deporte_id: '5',
+        capacidad: '12',
+        precio: '1000.555',
+        precio_dia: '1200.4',
+        precio_noche: '',
+        tipo_suelo: '  Cemento ',
+        techada: 'true',
+        iluminacion: '0',
+        estado: 'mantenimiento',
+      });
+
+    expect(res.status).toBe(201);
+    expect(CanchasModel.crearCancha).toHaveBeenCalledWith({
+      club_id: 10,
+      nombre: 'Cancha Central',
+      deporte_id: 5,
+      capacidad: 12,
+      precio: 1000.56,
+      precio_dia: 1200.4,
+      precio_noche: null,
+      tipo_suelo: 'Cemento',
+      techada: true,
+      iluminacion: false,
+      estado: 'mantenimiento',
+    });
+  });
+
+  it('impide actualizar con estado inválido', async () => {
+    const app = buildApp();
+    CanchasModel.obtenerCanchaPorId.mockResolvedValue({ cancha_id: 1, club_id: 10 });
+
+    const res = await request(app).patch('/mis-canchas/1').send({ estado: 'cerrada' });
+
+    expect(res.status).toBe(400);
+    expect(CanchasModel.actualizarCancha).not.toHaveBeenCalled();
+  });
+
+  it('actualiza cancha válida', async () => {
+    const app = buildApp();
+    CanchasModel.obtenerCanchaPorId.mockResolvedValue({ cancha_id: 1, club_id: 10 });
+    CanchasModel.actualizarCancha.mockResolvedValue({ cancha_id: 1, precio: 2000 });
+
+    const res = await request(app)
+      .patch('/mis-canchas/1')
+      .send({ precio: '2000', iluminacion: 1 });
+
+    expect(res.status).toBe(200);
+    expect(CanchasModel.actualizarCancha).toHaveBeenCalledWith(1, {
+      precio: 2000,
+      iluminacion: true,
+    });
+  });
+
+  it('elimina cancha existente', async () => {
+    const app = buildApp();
+    CanchasModel.obtenerCanchaPorId.mockResolvedValue({ cancha_id: 7, club_id: 10 });
+
+    const res = await request(app).delete('/mis-canchas/7');
+
+    expect(res.status).toBe(200);
+    expect(CanchasModel.eliminarCancha).toHaveBeenCalledWith(7);
+  });
+
+  it('rechaza subir imagen sin archivo', async () => {
+    const app = buildApp();
+    CanchasModel.obtenerCanchaPorId.mockResolvedValue({ cancha_id: 9, club_id: 10 });
+
+    const res = await request(app).post('/mis-canchas/9/imagen');
+
+    expect(res.status).toBe(400);
+    expect(CanchasModel.actualizarImagen).not.toHaveBeenCalled();
+  });
+
+  it('sube imagen y devuelve nueva ruta', async () => {
+    const app = buildApp();
+    CanchasModel.obtenerCanchaPorId
+      .mockResolvedValueOnce({ cancha_id: 11, club_id: 10, imagen_url: null })
+      .mockResolvedValueOnce({ cancha_id: 11, club_id: 10, imagen_url: '/uploads/canchas/nueva.png' });
+
+    CanchasModel.actualizarImagen.mockResolvedValue('/uploads/canchas/nueva.png');
+
+    global.__testCanchaFile = {
+      buffer: Buffer.from('file'),
+      mimetype: 'image/png',
+      originalname: 'foto.png',
+    };
+
+    const res = await request(app).post('/mis-canchas/11/imagen');
+
+    expect(res.status).toBe(200);
+    expect(CanchasModel.actualizarImagen).toHaveBeenCalledWith(11, global.__testCanchaFile);
+    expect(res.body).toHaveProperty('imagen_url', '/uploads/canchas/nueva.png');
+  });
+
+  it('devuelve resumen de cancha', async () => {
+    const app = buildApp();
+    CanchasModel.obtenerCanchaPorId.mockResolvedValue({ cancha_id: 3, club_id: 10 });
+    CanchasModel.obtenerResumen.mockResolvedValue({ disponibleAhora: true });
+
+    const res = await request(app).get('/mis-canchas/3/resumen');
+
+    expect(res.status).toBe(200);
+    expect(CanchasModel.obtenerResumen).toHaveBeenCalledWith(3);
+    expect(res.body).toHaveProperty('resumen');
+  });
+});


### PR DESCRIPTION
## Summary
- extend the canchas model with differentiated pricing fields, image storage helpers, and per-court summaries
- enrich the clubes model and routes to expose full cancha CRUD, validation, image upload, and summary endpoints
- cover the new behaviour with dedicated Jest tests for listing, creating, updating, deleting and summarizing canchas

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e53d479c08832fa7d89be403b3298e