### PR TITLE
feat: manage club courts from dashboard

### DIFF
--- a/meClub/src/screens/dashboard/CanchasScreen.jsx
+++ b/meClub/src/screens/dashboard/CanchasScreen.jsx
@@ -1,13 +1,460 @@
-import React from 'react';
-import { View, Text } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Image,
+  Platform,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  Text,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import Card from '../../components/Card';
+import {
+  createClubCourt,
+  deleteClubCourt,
+  getClubCourtSummary,
+  getClubCourts,
+  listSports,
+  resolveAssetUrl,
+  updateClubCourt,
+  uploadClubCourtImage,
+} from '../../lib/api';
+import CourtFormModal from './CourtFormModal';
+import CourtSummaryModal from './CourtSummaryModal';
 
-export default function CanchasScreen() {
+const STATUS_COLORS = {
+  disponible: 'text-emerald-400',
+  mantenimiento: 'text-amber-400',
+  inactiva: 'text-red-400',
+};
+
+function formatCurrency(value) {
+  if (value === null || value === undefined || value === '') {
+    return 'Sin definir';
+  }
+  const num = Number(value);
+  if (!Number.isFinite(num)) return 'Sin definir';
+  try {
+    return new Intl.NumberFormat('es-AR', {
+      style: 'currency',
+      currency: 'ARS',
+      maximumFractionDigits: 0,
+    }).format(num);
+  } catch {
+    return `$${Math.round(num)}`;
+  }
+}
+
+function formatBoolean(value) {
+  if (value === null || value === undefined) return 'Sin definir';
+  return value ? 'Sí' : 'No';
+}
+
+function statusLabel(value) {
+  switch (value) {
+    case 'mantenimiento':
+      return 'En mantenimiento';
+    case 'inactiva':
+      return 'Inactiva';
+    case 'disponible':
+    default:
+      return 'Disponible';
+  }
+}
+
+function confirmDeletion(courtName, onConfirm) {
+  if (Platform.OS === 'web') {
+    // eslint-disable-next-line no-alert
+    const accepted = typeof window !== 'undefined' ? window.confirm(`¿Eliminar ${courtName}?`) : true;
+    if (accepted) onConfirm();
+    return;
+  }
+  Alert.alert(
+    'Eliminar cancha',
+    courtName ? `¿Seguro que querés eliminar ${courtName}?` : '¿Seguro que querés eliminar esta cancha?',
+    [
+      { text: 'Cancelar', style: 'cancel' },
+      { text: 'Eliminar', style: 'destructive', onPress: onConfirm },
+    ]
+  );
+}
+
+export default function CanchasScreen({ go }) {
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState('');
+  const [courts, setCourts] = useState([]);
+  const [sports, setSports] = useState([]);
+  const [formVisible, setFormVisible] = useState(false);
+  const [formMode, setFormMode] = useState('create');
+  const [formLoading, setFormLoading] = useState(false);
+  const [formError, setFormError] = useState('');
+  const [activeCourt, setActiveCourt] = useState(null);
+  const [summaryVisible, setSummaryVisible] = useState(false);
+  const [summaryLoading, setSummaryLoading] = useState(false);
+  const [summaryError, setSummaryError] = useState('');
+  const [summaryData, setSummaryData] = useState(null);
+
+  const loadCourts = useCallback(async ({ showSpinner = false } = {}) => {
+    if (showSpinner) {
+      setLoading(true);
+    }
+    try {
+      const data = await getClubCourts();
+      setCourts(Array.isArray(data) ? data : []);
+      setError('');
+    } catch (err) {
+      setCourts([]);
+      setError(err?.message || 'No pudimos cargar tus canchas');
+    } finally {
+      if (showSpinner) {
+        setLoading(false);
+      }
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const list = await listSports();
+        if (alive && Array.isArray(list)) {
+          setSports(list);
+        }
+      } catch (err) {
+        console.warn('listSports', err);
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    loadCourts({ showSpinner: true });
+  }, [loadCourts]);
+
+  const onRefresh = useCallback(() => {
+    setRefreshing(true);
+    loadCourts();
+  }, [loadCourts]);
+
+  const handleOpenCreate = useCallback(() => {
+    setFormMode('create');
+    setActiveCourt(null);
+    setFormError('');
+    setFormVisible(true);
+  }, []);
+
+  const handleOpenEdit = useCallback((court) => {
+    setFormMode('edit');
+    setActiveCourt(court);
+    setFormError('');
+    setFormVisible(true);
+  }, []);
+
+  const handleSubmitForm = async ({ values, image }) => {
+    if (!values) return;
+    setFormLoading(true);
+    setFormError('');
+    try {
+      if (formMode === 'edit' && activeCourt) {
+        await updateClubCourt(activeCourt.cancha_id, values);
+        if (image) {
+          await uploadClubCourtImage(activeCourt.cancha_id, image);
+        }
+      } else {
+        const created = await createClubCourt(values);
+        const createdId = created?.cancha_id;
+        if (image && createdId) {
+          await uploadClubCourtImage(createdId, image);
+        }
+      }
+      await loadCourts();
+      setFormVisible(false);
+    } catch (err) {
+      setFormError(err?.message || 'No pudimos guardar los cambios');
+    } finally {
+      setFormLoading(false);
+    }
+  };
+
+  const handleDeleteCourt = useCallback(
+    async (court) => {
+      const performDelete = async () => {
+        try {
+          await deleteClubCourt(court.cancha_id);
+          await loadCourts();
+        } catch (err) {
+          setError(err?.message || 'No pudimos eliminar la cancha');
+        }
+      };
+      confirmDeletion(court?.nombre, performDelete);
+    },
+    [loadCourts]
+  );
+
+  const handleOpenSummary = useCallback(async (court) => {
+    setSummaryVisible(true);
+    setSummaryLoading(true);
+    setSummaryError('');
+    setSummaryData(null);
+    setActiveCourt(court);
+    try {
+      const data = await getClubCourtSummary(court.cancha_id);
+      setSummaryData(data || {});
+    } catch (err) {
+      setSummaryError(err?.message || 'No pudimos cargar el resumen');
+    } finally {
+      setSummaryLoading(false);
+    }
+  }, []);
+
+  const cards = useMemo(() => {
+    return courts.map((court) => {
+      const infoItems = [
+        {
+          icon: 'people-outline',
+          label: 'Capacidad',
+          value:
+            court.capacidad === null || court.capacidad === undefined
+              ? 'Sin definir'
+              : `${court.capacidad} jugadores`,
+        },
+        {
+          icon: 'cash-outline',
+          label: 'Precio base',
+          value: formatCurrency(court.precio),
+        },
+        {
+          icon: 'sunny-outline',
+          label: 'Turno día',
+          value: formatCurrency(court.precio_dia),
+        },
+        {
+          icon: 'moon-outline',
+          label: 'Turno noche',
+          value: formatCurrency(court.precio_noche),
+        },
+        {
+          icon: 'layers-outline',
+          label: 'Tipo de suelo',
+          value: court.tipo_suelo || 'Sin definir',
+        },
+        {
+          icon: 'home-outline',
+          label: 'Techada',
+          value: formatBoolean(court.techada),
+        },
+        {
+          icon: 'bulb-outline',
+          label: 'Iluminación',
+          value: formatBoolean(court.iluminacion),
+        },
+        {
+          icon: 'checkmark-circle-outline',
+          label: 'Estado',
+          value: statusLabel(court.estado),
+          status: court.estado,
+        },
+      ];
+
+      const preview = court.imagen_url ? resolveAssetUrl(court.imagen_url) : null;
+
+      return (
+        <Card key={court.cancha_id} className="mb-6">
+          <View className="flex-col gap-4 md:flex-row md:gap-6">
+            <View className="w-full md:w-48">
+              <View className="h-40 w-full overflow-hidden rounded-2xl border border-white/10 bg-white/5 items-center justify-center">
+                {preview ? (
+                  <Image source={{ uri: preview }} className="h-full w-full" resizeMode="cover" />
+                ) : (
+                  <Ionicons name="image-outline" size={32} color="#94A3B8" />
+                )}
+              </View>
+            </View>
+
+            <View className="flex-1">
+              <View className="flex-row flex-wrap items-center justify-between gap-3">
+                <View className="flex-1">
+                  <Text className="text-white text-2xl font-semibold tracking-tight">
+                    {court.nombre}
+                  </Text>
+                  <Text className="text-white/60 text-sm mt-1">
+                    {court.deporte_nombre || 'Deporte no especificado'}
+                  </Text>
+                </View>
+                <Pressable
+                  onPress={() => handleDeleteCourt(court)}
+                  className="rounded-2xl border border-red-400/30 bg-red-400/10 px-4 py-2 hover:bg-red-400/20"
+                >
+                  <View className="flex-row items-center gap-2">
+                    <Ionicons name="trash-outline" size={16} color="#FCA5A5" />
+                    <Text className="text-[#FCA5A5] text-sm font-medium">Eliminar</Text>
+                  </View>
+                </Pressable>
+              </View>
+
+              <View className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+                {infoItems.map((item) => (
+                  <View
+                    key={`${court.cancha_id}-${item.label}`}
+                    className="flex-row items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3"
+                  >
+                    <Ionicons name={item.icon} size={18} color="#FBBF24" />
+                    <View className="flex-1">
+                      <Text className="text-white/50 text-xs uppercase tracking-widest">
+                        {item.label}
+                      </Text>
+                      <Text
+                        className={`text-white text-sm font-medium ${
+                          item.status ? STATUS_COLORS[item.status] || 'text-white' : ''
+                        }`}
+                      >
+                        {item.value}
+                      </Text>
+                    </View>
+                  </View>
+                ))}
+              </View>
+
+              <View className="mt-6 flex-row flex-wrap gap-3">
+                <Pressable
+                  onPress={() => handleOpenSummary(court)}
+                  className="rounded-2xl border border-white/10 bg-white/5 px-4 py-2 hover:bg-white/10"
+                >
+                  <View className="flex-row items-center gap-2">
+                    <Ionicons name="bar-chart-outline" size={16} color="#FBBF24" />
+                    <Text className="text-white/80 text-sm font-medium">Ver estado</Text>
+                  </View>
+                </Pressable>
+                <Pressable
+                  onPress={() => handleOpenEdit(court)}
+                  className="rounded-2xl bg-mc-warn px-4 py-2 hover:bg-mc-warn/80"
+                >
+                  <View className="flex-row items-center gap-2">
+                    <Ionicons name="create-outline" size={16} color="#0A0F1D" />
+                    <Text className="text-[#0A0F1D] text-sm font-semibold">Editar</Text>
+                  </View>
+                </Pressable>
+              </View>
+            </View>
+          </View>
+        </Card>
+      );
+    });
+  }, [courts, handleDeleteCourt, handleOpenEdit, handleOpenSummary]);
+
+  const renderContent = () => {
+    if (loading) {
+      return (
+        <View className="flex-1 items-center justify-center py-20">
+          <ActivityIndicator color="#F59E0B" size="large" />
+          <Text className="text-white/70 mt-4">Cargando tus canchas...</Text>
+        </View>
+      );
+    }
+
+    if (error) {
+      return (
+        <View className="flex-1 items-center justify-center py-20 px-6">
+          <Ionicons name="warning-outline" size={32} color="#F97316" />
+          <Text className="text-white/80 text-center text-base mt-3">{error}</Text>
+          <Pressable
+            onPress={() => loadCourts({ showSpinner: true })}
+            className="mt-4 rounded-2xl bg-mc-warn px-4 py-2 hover:bg-mc-warn/80"
+          >
+            <Text className="text-[#0A0F1D] text-sm font-semibold">Reintentar</Text>
+          </Pressable>
+        </View>
+      );
+    }
+
+    if (!courts.length) {
+      return (
+        <View className="items-center justify-center py-20 px-6">
+          <View className="h-20 w-20 items-center justify-center rounded-full border border-white/10 bg-white/5">
+            <Ionicons name="tennisball-outline" size={28} color="#FBBF24" />
+          </View>
+          <Text className="text-white text-xl font-semibold mt-6">Todavía no cargaste canchas</Text>
+          <Text className="text-white/60 text-center mt-2 max-w-xl">
+            Creá tu primera cancha para empezar a tomar reservas y mantener toda la información actualizada.
+          </Text>
+          <Pressable
+            onPress={handleOpenCreate}
+            className="mt-6 rounded-2xl bg-mc-warn px-6 py-3 hover:bg-mc-warn/80"
+          >
+            <Text className="text-[#0A0F1D] text-sm font-semibold">Agregar cancha</Text>
+          </Pressable>
+        </View>
+      );
+    }
+
+    return <View className="mt-8 px-4 md:px-0">{cards}</View>;
+  };
+
   return (
     <View className="flex-1">
-      <View className="py-6">
-        <Text className="text-white text-[36px] font-extrabold tracking-tight">Mis Canchas</Text>
-        <Text className="text-white/60 mt-1">Próximamente</Text>
-      </View>
+      <ScrollView
+        className="py-6"
+        contentContainerClassName="pb-28"
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor="#F59E0B" />}
+      >
+        <View className="flex-row flex-wrap items-center justify-between gap-3 px-4 md:px-0">
+          <View>
+            <Text className="text-white text-[32px] font-extrabold tracking-tight">Mis Canchas</Text>
+            <Text className="text-white/60 mt-1">Gestioná los espacios disponibles en tu club</Text>
+          </View>
+          <View className="flex-row flex-wrap items-center gap-3">
+            <Pressable
+              onPress={() => go?.('inicio')}
+              className="rounded-2xl border border-white/10 bg-white/5 px-4 py-2 hover:bg-white/10"
+            >
+              <Text className="text-white/80 text-sm font-medium">Volver al inicio</Text>
+            </Pressable>
+            <Pressable
+              onPress={handleOpenCreate}
+              className="rounded-2xl bg-mc-warn px-4 py-2 hover:bg-mc-warn/80"
+            >
+              <View className="flex-row items-center gap-2">
+                <Ionicons name="add" size={18} color="#0A0F1D" />
+                <Text className="text-[#0A0F1D] text-sm font-semibold">Agregar cancha</Text>
+              </View>
+            </Pressable>
+          </View>
+        </View>
+
+        {renderContent()}
+      </ScrollView>
+
+      <CourtFormModal
+        visible={formVisible}
+        onDismiss={() => {
+          if (!formLoading) {
+            setFormVisible(false);
+            setFormError('');
+          }
+        }}
+        onSubmit={handleSubmitForm}
+        initialValues={formMode === 'edit' ? activeCourt : null}
+        loading={formLoading}
+        title={formMode === 'edit' ? 'Editar cancha' : 'Agregar cancha'}
+        sports={sports}
+        errorMessage={formError}
+      />
+
+      <CourtSummaryModal
+        visible={summaryVisible}
+        onClose={() => setSummaryVisible(false)}
+        court={activeCourt}
+        summary={summaryData}
+        loading={summaryLoading}
+        error={summaryError}
+      />
     </View>
   );
 }

--- a/meClub/src/screens/dashboard/CourtFormModal.jsx
+++ b/meClub/src/screens/dashboard/CourtFormModal.jsx
@@ -1,0 +1,483 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  Switch,
+  Text,
+  TextInput,
+  View,
+  Image,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import * as ImagePicker from 'expo-image-picker';
+import Card from '../../components/Card';
+import { resolveAssetUrl } from '../../lib/api';
+
+const FIELD_STYLES =
+  'w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:border-mc-warn';
+
+const DEFAULT_VALUES = {
+  nombre: '',
+  deporte_id: null,
+  capacidad: '',
+  precio: '',
+  precio_dia: '',
+  precio_noche: '',
+  tipo_suelo: '',
+  techada: false,
+  iluminacion: false,
+  estado: 'disponible',
+  imagen_url: null,
+};
+
+const ESTADOS = [
+  { value: 'disponible', label: 'Disponible' },
+  { value: 'mantenimiento', label: 'En mantenimiento' },
+  { value: 'inactiva', label: 'Inactiva' },
+];
+
+function useInitialFormValues(initialValues) {
+  return useMemo(() => {
+    if (!initialValues || typeof initialValues !== 'object') {
+      return DEFAULT_VALUES;
+    }
+    return {
+      ...DEFAULT_VALUES,
+      ...initialValues,
+      capacidad:
+        initialValues.capacidad === null || initialValues.capacidad === undefined
+          ? ''
+          : String(initialValues.capacidad),
+      precio:
+        initialValues.precio === null || initialValues.precio === undefined
+          ? ''
+          : String(initialValues.precio),
+      precio_dia:
+        initialValues.precio_dia === null || initialValues.precio_dia === undefined
+          ? ''
+          : String(initialValues.precio_dia),
+      precio_noche:
+        initialValues.precio_noche === null || initialValues.precio_noche === undefined
+          ? ''
+          : String(initialValues.precio_noche),
+      tipo_suelo: initialValues.tipo_suelo || '',
+      deporte_id: initialValues.deporte_id ?? null,
+      estado: initialValues.estado || 'disponible',
+    };
+  }, [initialValues]);
+}
+
+export default function CourtFormModal({
+  visible,
+  onDismiss,
+  onSubmit,
+  initialValues,
+  loading,
+  title,
+  sports = [],
+  errorMessage,
+}) {
+  const [form, setForm] = useState(DEFAULT_VALUES);
+  const [errors, setErrors] = useState({});
+  const [imageAsset, setImageAsset] = useState(null);
+  const [imageError, setImageError] = useState('');
+  const [pickingImage, setPickingImage] = useState(false);
+  const [showSportPicker, setShowSportPicker] = useState(false);
+
+  const parsedInitialValues = useInitialFormValues(initialValues);
+
+  useEffect(() => {
+    if (!visible) return;
+    setForm(parsedInitialValues);
+    setErrors({});
+    setImageAsset(null);
+    setImageError('');
+    setShowSportPicker(false);
+  }, [visible, parsedInitialValues]);
+
+  const previewUri = useMemo(() => {
+    if (imageAsset?.uri) return imageAsset.uri;
+    if (form?.imagen_url) return resolveAssetUrl(form.imagen_url);
+    if (initialValues?.imagen_url) return resolveAssetUrl(initialValues.imagen_url);
+    return null;
+  }, [imageAsset?.uri, form?.imagen_url, initialValues?.imagen_url]);
+
+  const handleChange = (key, value) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const toggleBoolean = (key) => {
+    setForm((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const validate = () => {
+    const nextErrors = {};
+    if (!form.nombre || !String(form.nombre).trim()) {
+      nextErrors.nombre = 'Ingresá un nombre';
+    }
+    if (!form.deporte_id) {
+      nextErrors.deporte_id = 'Seleccioná un deporte';
+    }
+    if (form.capacidad === '' || form.capacidad === null) {
+      nextErrors.capacidad = 'Indicá la capacidad';
+    } else if (Number.isNaN(Number(form.capacidad))) {
+      nextErrors.capacidad = 'Capacidad inválida';
+    }
+    if (form.precio === '' || form.precio === null) {
+      nextErrors.precio = 'Indicá el precio base';
+    } else if (Number.isNaN(Number(form.precio))) {
+      nextErrors.precio = 'Precio inválido';
+    }
+    setErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  };
+
+  const normalizeDecimal = (value) => {
+    if (value === '' || value === null || value === undefined) {
+      return null;
+    }
+    const sanitized = typeof value === 'number' ? value : Number(String(value).replace(',', '.'));
+    const num = typeof sanitized === 'number' ? sanitized : Number(sanitized);
+    if (!Number.isFinite(num)) return null;
+    return Number(num.toFixed(2));
+  };
+
+  const normalizeInteger = (value) => {
+    if (value === '' || value === null || value === undefined) {
+      return null;
+    }
+    const num = Number(value);
+    if (!Number.isFinite(num)) return null;
+    return Math.max(0, Math.trunc(num));
+  };
+
+  const handleSubmit = () => {
+    if (!validate()) return;
+    const payload = {
+      nombre: String(form.nombre).trim(),
+      deporte_id: form.deporte_id ? Number(form.deporte_id) : null,
+      capacidad: normalizeInteger(form.capacidad),
+      precio: normalizeDecimal(form.precio),
+      precio_dia: normalizeDecimal(form.precio_dia),
+      precio_noche: normalizeDecimal(form.precio_noche),
+      tipo_suelo: form.tipo_suelo ? String(form.tipo_suelo).trim() : null,
+      techada: !!form.techada,
+      iluminacion: !!form.iluminacion,
+      estado: form.estado || 'disponible',
+    };
+
+    onSubmit?.({ values: payload, image: imageAsset });
+  };
+
+  const ensurePermissions = async () => {
+    if (Platform.OS === 'web') {
+      return true;
+    }
+    const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (status !== 'granted') {
+      setImageError('Necesitamos permisos para acceder a tus imágenes');
+      return false;
+    }
+    return true;
+  };
+
+  const handlePickImage = async () => {
+    try {
+      setPickingImage(true);
+      setImageError('');
+      const allowed = await ensurePermissions();
+      if (!allowed) return;
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        quality: 0.85,
+        allowsEditing: Platform.OS !== 'web',
+      });
+      if (!result.canceled && Array.isArray(result.assets) && result.assets.length > 0) {
+        setImageAsset(result.assets[0]);
+      }
+    } catch (err) {
+      setImageError(err?.message || 'No pudimos seleccionar la imagen');
+    } finally {
+      setPickingImage(false);
+    }
+  };
+
+  const renderSportPicker = () => {
+    if (!showSportPicker) return null;
+    return (
+      <View className="absolute inset-0 bg-black/50 items-center justify-center px-4">
+        <Card className="w-full max-w-xl max-h-[480px]">
+          <View className="flex-row items-center justify-between mb-4">
+            <Text className="text-white text-lg font-semibold">Seleccioná un deporte</Text>
+            <Pressable
+              onPress={() => setShowSportPicker(false)}
+              className="h-9 w-9 items-center justify-center rounded-full bg-white/5"
+            >
+              <Ionicons name="close" size={18} color="white" />
+            </Pressable>
+          </View>
+          <ScrollView className="max-h-[360px]" contentContainerClassName="pb-2">
+            {(sports || []).map((sport) => (
+              <Pressable
+                key={sport.deporte_id || sport.id || sport.nombre}
+                onPress={() => {
+                  setForm((prev) => ({
+                    ...prev,
+                    deporte_id: sport.deporte_id ?? sport.id,
+                  }));
+                  setShowSportPicker(false);
+                }}
+                className={`rounded-xl px-4 py-3 mb-2 border border-white/5 ${
+                  String(form.deporte_id) === String(sport.deporte_id ?? sport.id)
+                    ? 'bg-white/10 border-mc-warn'
+                    : 'bg-white/5'
+                }`}
+              >
+                <Text className="text-white text-base font-medium">{sport.nombre}</Text>
+                {sport.descripcion ? (
+                  <Text className="text-white/60 text-sm mt-1">{sport.descripcion}</Text>
+                ) : null}
+              </Pressable>
+            ))}
+            {(sports || []).length === 0 && (
+              <Text className="text-white/60 text-sm text-center">
+                No encontramos deportes disponibles
+              </Text>
+            )}
+          </ScrollView>
+        </Card>
+      </View>
+    );
+  };
+
+  return (
+    <Modal
+      animationType="fade"
+      transparent
+      visible={visible}
+      onRequestClose={() => {
+        if (!loading) {
+          onDismiss?.();
+        }
+      }}
+    >
+      <View className="flex-1 bg-black/60 items-center justify-center px-4">
+        <Card className="w-full max-w-3xl max-h-[90vh]">
+          <View className="flex-row items-center justify-between mb-6">
+            <View>
+              <Text className="text-white text-2xl font-bold tracking-tight">{title}</Text>
+              <Text className="text-white/60 text-sm mt-1">
+                Completá los datos obligatorios marcados con *
+              </Text>
+            </View>
+            <Pressable
+              onPress={() => {
+                if (!loading) onDismiss?.();
+              }}
+              className="h-10 w-10 items-center justify-center rounded-full bg-white/5"
+            >
+              <Ionicons name="close" size={20} color="#FFFFFF" />
+            </Pressable>
+          </View>
+
+          {errorMessage ? (
+            <View className="mb-4 rounded-2xl border border-white/10 bg-[#2F1B1B]/80 px-4 py-3">
+              <Text className="text-[#FCA5A5] text-sm">{errorMessage}</Text>
+            </View>
+          ) : null}
+
+          <ScrollView className="flex-1" contentContainerClassName="pb-6">
+            <View className="gap-4">
+              <View>
+                <Text className="text-white/70 text-sm mb-2">Nombre *</Text>
+                <TextInput
+                  value={form.nombre}
+                  onChangeText={(text) => handleChange('nombre', text)}
+                  placeholder="Cancha 1"
+                  placeholderTextColor="#94A3B8"
+                  className={FIELD_STYLES}
+                />
+                {errors.nombre ? (
+                  <Text className="text-mc-warn text-xs mt-1">{errors.nombre}</Text>
+                ) : null}
+              </View>
+
+              <View>
+                <Text className="text-white/70 text-sm mb-2">Deporte *</Text>
+                <Pressable
+                  onPress={() => setShowSportPicker(true)}
+                  className={`${FIELD_STYLES} flex-row items-center justify-between`}
+                >
+                  <Text className="text-white/90 text-base">
+                    {sports?.find((sport) => String(sport.deporte_id ?? sport.id) === String(form.deporte_id))?.nombre ||
+                      'Seleccioná un deporte'}
+                  </Text>
+                  <Ionicons name="chevron-down" size={18} color="#94A3B8" />
+                </Pressable>
+                {errors.deporte_id ? (
+                  <Text className="text-mc-warn text-xs mt-1">{errors.deporte_id}</Text>
+                ) : null}
+              </View>
+
+              <View className="flex-row flex-wrap gap-4">
+                <View className="flex-1 min-w-[140px]">
+                  <Text className="text-white/70 text-sm mb-2">Capacidad *</Text>
+                  <TextInput
+                    value={form.capacidad}
+                    onChangeText={(text) => handleChange('capacidad', text.replace(/[^0-9]/g, ''))}
+                    keyboardType="numeric"
+                    placeholder="4"
+                    placeholderTextColor="#94A3B8"
+                    className={FIELD_STYLES}
+                  />
+                  {errors.capacidad ? (
+                    <Text className="text-mc-warn text-xs mt-1">{errors.capacidad}</Text>
+                  ) : null}
+                </View>
+                <View className="flex-1 min-w-[180px]">
+                  <Text className="text-white/70 text-sm mb-2">Precio base *</Text>
+                  <TextInput
+                    value={form.precio}
+                    onChangeText={(text) => handleChange('precio', text.replace(/[^0-9.,]/g, ''))}
+                    keyboardType="decimal-pad"
+                    placeholder="2500"
+                    placeholderTextColor="#94A3B8"
+                    className={FIELD_STYLES}
+                  />
+                  {errors.precio ? (
+                    <Text className="text-mc-warn text-xs mt-1">{errors.precio}</Text>
+                  ) : null}
+                </View>
+              </View>
+
+              <View className="flex-row flex-wrap gap-4">
+                <View className="flex-1 min-w-[180px]">
+                  <Text className="text-white/70 text-sm mb-2">Precio turno día</Text>
+                  <TextInput
+                    value={form.precio_dia}
+                    onChangeText={(text) => handleChange('precio_dia', text.replace(/[^0-9.,]/g, ''))}
+                    keyboardType="decimal-pad"
+                    placeholder="2300"
+                    placeholderTextColor="#94A3B8"
+                    className={FIELD_STYLES}
+                  />
+                </View>
+                <View className="flex-1 min-w-[180px]">
+                  <Text className="text-white/70 text-sm mb-2">Precio turno noche</Text>
+                  <TextInput
+                    value={form.precio_noche}
+                    onChangeText={(text) => handleChange('precio_noche', text.replace(/[^0-9.,]/g, ''))}
+                    keyboardType="decimal-pad"
+                    placeholder="2700"
+                    placeholderTextColor="#94A3B8"
+                    className={FIELD_STYLES}
+                  />
+                </View>
+              </View>
+
+              <View>
+                <Text className="text-white/70 text-sm mb-2">Tipo de suelo</Text>
+                <TextInput
+                  value={form.tipo_suelo}
+                  onChangeText={(text) => handleChange('tipo_suelo', text)}
+                  placeholder="Cemento, césped, parquet..."
+                  placeholderTextColor="#94A3B8"
+                  className={FIELD_STYLES}
+                />
+              </View>
+
+              <View className="flex-row flex-wrap gap-4">
+                <View className="flex-1 min-w-[160px]">
+                  <Text className="text-white/70 text-sm mb-2">Techada</Text>
+                  <View className="flex-row items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                    <Text className="text-white/80">{form.techada ? 'Sí' : 'No'}</Text>
+                    <Switch value={!!form.techada} onValueChange={() => toggleBoolean('techada')} />
+                  </View>
+                </View>
+                <View className="flex-1 min-w-[160px]">
+                  <Text className="text-white/70 text-sm mb-2">Iluminación</Text>
+                  <View className="flex-row items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                    <Text className="text-white/80">{form.iluminacion ? 'Sí' : 'No'}</Text>
+                    <Switch value={!!form.iluminacion} onValueChange={() => toggleBoolean('iluminacion')} />
+                  </View>
+                </View>
+              </View>
+
+              <View>
+                <Text className="text-white/70 text-sm mb-2">Estado</Text>
+                <View className="flex-row flex-wrap gap-2">
+                  {ESTADOS.map((state) => {
+                    const active = form.estado === state.value;
+                    return (
+                      <Pressable
+                        key={state.value}
+                        onPress={() => handleChange('estado', state.value)}
+                        className={`rounded-2xl px-4 py-2 border text-sm font-medium ${
+                          active ? 'border-mc-warn bg-mc-warn/20 text-mc-warn' : 'border-white/10 bg-white/5 text-white/80'
+                        }`}
+                      >
+                        <Text className={active ? 'text-mc-warn' : 'text-white/80'}>{state.label}</Text>
+                      </Pressable>
+                    );
+                  })}
+                </View>
+              </View>
+
+              <View>
+                <Text className="text-white/70 text-sm mb-2">Imagen destacada</Text>
+                <View className="flex-row items-center gap-4">
+                  <View className="h-24 w-32 rounded-2xl border border-white/10 bg-white/5 overflow-hidden items-center justify-center">
+                    {previewUri ? (
+                      <Image source={{ uri: previewUri }} className="h-full w-full" resizeMode="cover" />
+                    ) : (
+                      <Ionicons name="image-outline" size={24} color="#94A3B8" />
+                    )}
+                  </View>
+                  <View className="flex-1 gap-2">
+                    <Pressable
+                      onPress={handlePickImage}
+                      disabled={pickingImage}
+                      className="rounded-2xl border border-white/10 bg-white/5 px-4 py-2 self-start hover:bg-white/10"
+                    >
+                      <Text className="text-white/80 text-sm font-medium">
+                        {pickingImage ? 'Abriendo biblioteca...' : 'Seleccionar imagen'}
+                      </Text>
+                    </Pressable>
+                    {imageError ? <Text className="text-mc-warn text-xs">{imageError}</Text> : null}
+                    <Text className="text-white/40 text-xs">
+                      Formatos admitidos: JPG, PNG, WEBP. Tamaño recomendado 1200x800px.
+                    </Text>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </ScrollView>
+
+          <View className="flex-row items-center justify-end gap-3 border-t border-white/5 pt-4">
+            <Pressable
+              onPress={() => {
+                if (!loading) onDismiss?.();
+              }}
+              disabled={loading}
+              className="rounded-2xl border border-white/10 bg-white/5 px-4 py-2 hover:bg-white/10"
+            >
+              <Text className="text-white/80 text-sm font-medium">Cancelar</Text>
+            </Pressable>
+            <Pressable
+              onPress={handleSubmit}
+              disabled={loading}
+              className="rounded-2xl bg-mc-warn px-5 py-2 hover:bg-mc-warn/80"
+            >
+              <Text className="text-[#0A0F1D] text-sm font-semibold">
+                {loading ? 'Guardando...' : 'Guardar cambios'}
+              </Text>
+            </Pressable>
+          </View>
+        </Card>
+        {renderSportPicker()}
+      </View>
+    </Modal>
+  );
+}

--- a/meClub/src/screens/dashboard/CourtSummaryModal.jsx
+++ b/meClub/src/screens/dashboard/CourtSummaryModal.jsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import { ActivityIndicator, Modal, Pressable, ScrollView, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import Card from '../../components/Card';
+
+function formatDate(dateStr) {
+  if (!dateStr) return '';
+  try {
+    const date = new Date(dateStr);
+    return new Intl.DateTimeFormat('es-AR', {
+      weekday: 'short',
+      day: '2-digit',
+      month: 'short',
+    }).format(date);
+  } catch {
+    return dateStr;
+  }
+}
+
+function formatTime(value) {
+  if (!value) return '';
+  return value.slice(0, 5);
+}
+
+export default function CourtSummaryModal({ visible, onClose, court, summary, loading, error }) {
+  const estado = summary?.estado || court?.estado || 'disponible';
+  const estadoLabel = {
+    disponible: 'Disponible',
+    mantenimiento: 'En mantenimiento',
+    inactiva: 'Inactiva',
+  }[estado] || estado;
+
+  const disponibleAhora = summary?.disponibleAhora;
+  const proximas = summary?.proximasReservas || [];
+  const reservasHoy = summary?.reservasHoy || [];
+  const proximaReserva = summary?.proximaReserva;
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={() => {
+        onClose?.();
+      }}
+    >
+      <View className="flex-1 bg-black/70 items-center justify-center px-4">
+        <Card className="w-full max-w-3xl max-h-[85vh]">
+          <View className="flex-row items-center justify-between mb-5">
+            <View>
+              <Text className="text-white text-2xl font-bold tracking-tight">Estado general</Text>
+              <Text className="text-white/60 text-sm mt-1">
+                {court?.nombre ? `Resumen de ${court.nombre}` : 'Detalle de la cancha'}
+              </Text>
+            </View>
+            <Pressable
+              onPress={() => onClose?.()}
+              className="h-10 w-10 items-center justify-center rounded-full bg-white/5"
+            >
+              <Ionicons name="close" size={20} color="#FFFFFF" />
+            </Pressable>
+          </View>
+
+          {loading ? (
+            <View className="py-16 items-center justify-center gap-3">
+              <ActivityIndicator color="#F59E0B" size="large" />
+              <Text className="text-white/70">Cargando estado...</Text>
+            </View>
+          ) : error ? (
+            <View className="py-12 items-center">
+              <Ionicons name="warning" size={28} color="#F97316" />
+              <Text className="text-white/80 text-sm mt-2 text-center px-4">{error}</Text>
+            </View>
+          ) : (
+            <ScrollView className="flex-1" contentContainerClassName="pb-4 gap-6">
+              <View className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <View className="rounded-2xl border border-white/10 bg-white/5 px-4 py-4">
+                  <Text className="text-white/60 text-xs uppercase tracking-widest">Estado</Text>
+                  <Text className="text-white text-xl font-semibold mt-2">{estadoLabel}</Text>
+                  <Text className="text-white/60 text-sm mt-1">
+                    {disponibleAhora
+                      ? 'Disponible para reservar en este momento'
+                      : 'No disponible ahora mismo'}
+                  </Text>
+                </View>
+
+                <View className="rounded-2xl border border-white/10 bg-white/5 px-4 py-4">
+                  <Text className="text-white/60 text-xs uppercase tracking-widest">Reservas hoy</Text>
+                  <Text className="text-white text-3xl font-bold mt-2">{reservasHoy.length}</Text>
+                  <Text className="text-white/50 text-sm mt-1">Total de turnos registrados para hoy</Text>
+                </View>
+
+                <View className="rounded-2xl border border-white/10 bg-white/5 px-4 py-4">
+                  <Text className="text-white/60 text-xs uppercase tracking-widest">Próxima reserva</Text>
+                  {proximaReserva ? (
+                    <View className="mt-2">
+                      <Text className="text-white text-base font-medium">
+                        {formatDate(proximaReserva.fecha)}
+                      </Text>
+                      <Text className="text-white/70 text-sm mt-1">
+                        {formatTime(proximaReserva.hora_inicio)} - {formatTime(proximaReserva.hora_fin)}
+                      </Text>
+                      <Text className="text-white/40 text-xs mt-1">Estado: {proximaReserva.estado}</Text>
+                    </View>
+                  ) : (
+                    <Text className="text-white/60 text-sm mt-2">No hay reservas próximas</Text>
+                  )}
+                </View>
+
+                <View className="rounded-2xl border border-white/10 bg-white/5 px-4 py-4">
+                  <Text className="text-white/60 text-xs uppercase tracking-widest">Próximos turnos</Text>
+                  <Text className="text-white text-3xl font-bold mt-2">{proximas.length}</Text>
+                  <Text className="text-white/50 text-sm mt-1">
+                    Turnos agendados para los próximos días
+                  </Text>
+                </View>
+              </View>
+
+              <View>
+                <Text className="text-white/80 text-base font-semibold mb-3">Detalle de reservas</Text>
+                {reservasHoy.length === 0 && proximas.length === 0 ? (
+                  <View className="rounded-2xl border border-white/10 bg-white/5 px-4 py-6 items-center">
+                    <Ionicons name="calendar-outline" size={22} color="#94A3B8" />
+                    <Text className="text-white/60 text-sm mt-2 text-center">
+                      Esta cancha no tiene reservas registradas recientemente.
+                    </Text>
+                  </View>
+                ) : (
+                  <View className="rounded-2xl border border-white/10 bg-white/5">
+                    <View className="border-b border-white/5 px-4 py-3">
+                      <Text className="text-white/50 text-xs uppercase tracking-widest">Hoy</Text>
+                      {reservasHoy.length === 0 ? (
+                        <Text className="text-white/60 text-sm mt-1">Sin reservas para hoy</Text>
+                      ) : (
+                        reservasHoy.map((item, idx) => (
+                          <View
+                            key={`${item.reserva_id || idx}-today`}
+                            className="flex-row items-center justify-between py-2"
+                          >
+                            <Text className="text-white/70 text-sm">
+                              {formatTime(item.hora_inicio)} - {formatTime(item.hora_fin)}
+                            </Text>
+                            <Text className="text-white/40 text-xs uppercase tracking-wide">
+                              {item.estado}
+                            </Text>
+                          </View>
+                        ))
+                      )}
+                    </View>
+                    <View className="px-4 py-3">
+                      <Text className="text-white/50 text-xs uppercase tracking-widest">Próximas</Text>
+                      {proximas.length === 0 ? (
+                        <Text className="text-white/60 text-sm mt-1">Sin reservas próximas</Text>
+                      ) : (
+                        proximas.map((item, idx) => (
+                          <View
+                            key={`${item.reserva_id || idx}-next`}
+                            className="py-2 border-b border-white/5 last:border-b-0"
+                          >
+                            <Text className="text-white text-sm font-medium">
+                              {formatDate(item.fecha)}
+                            </Text>
+                            <Text className="text-white/70 text-sm mt-1">
+                              {formatTime(item.hora_inicio)} - {formatTime(item.hora_fin)}
+                            </Text>
+                            <Text className="text-white/40 text-xs uppercase tracking-wide mt-1">
+                              {item.estado}
+                            </Text>
+                          </View>
+                        ))
+                      )}
+                    </View>
+                  </View>
+                )}
+              </View>
+            </ScrollView>
+          )}
+        </Card>
+      </View>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Summary
- redesign the "Mis Canchas" dashboard screen with persistent navigation actions, card layout and CRUD wiring
- implement reusable court form and summary modals that work on web and native with Expo image picking support
- add API helpers for court listing, mutations, uploads and summaries to back the new UI

## Testing
- not run (UI change)

------
https://chatgpt.com/codex/tasks/task_e_68e5413e28b8832fbc155a7975ddf832