### PR TITLE
Light- 0.3.71025.1511

### DIFF
--- a/backend/models/canchas.model.js
+++ b/backend/models/canchas.model.js
@@ -37,11 +37,15 @@ const mapCanchaRow = (row) => {
     return String(value);
   };
 
+  const precioDia = normalizeDecimal(row.precio_dia);
+  const precioNoche = normalizeDecimal(row.precio_noche);
+  const precioBase = precioDia !== null ? precioDia : precioNoche;
+
   return {
     ...row,
-    precio: normalizeDecimal(row.precio),
-    precio_dia: normalizeDecimal(row.precio_dia),
-    precio_noche: normalizeDecimal(row.precio_noche),
+    precio: precioBase,
+    precio_dia: precioDia,
+    precio_noche: precioNoche,
     capacidad: normalizeInteger(row.capacidad),
     techada: !!row.techada,
     iluminacion: !!row.iluminacion,

--- a/backend/models/clubes.model.js
+++ b/backend/models/clubes.model.js
@@ -142,7 +142,7 @@ const ClubesModel = {
 
   obtenerMisCanchas: async (club_id) => {
     const [rows] = await db.query(
-      `SELECT c.cancha_id, c.club_id, c.nombre, c.deporte_id, c.capacidad, c.precio, c.precio_dia,
+      `SELECT c.cancha_id, c.club_id, c.nombre, c.deporte_id, c.capacidad, c.precio_dia,
               c.precio_noche, c.tipo_suelo, c.techada, c.iluminacion, c.estado, c.imagen_url,
               d.nombre AS deporte_nombre
        FROM canchas c
@@ -159,11 +159,16 @@ const ClubesModel = {
       deporte_id: row.deporte_id,
       deporte_nombre: row.deporte_nombre || null,
       capacidad: row.capacidad === null || row.capacidad === undefined ? null : Number(row.capacidad),
-      precio: row.precio === null || row.precio === undefined ? null : Number(row.precio),
       precio_dia:
         row.precio_dia === null || row.precio_dia === undefined ? null : Number(row.precio_dia),
       precio_noche:
         row.precio_noche === null || row.precio_noche === undefined ? null : Number(row.precio_noche),
+      precio:
+        row.precio_dia === null || row.precio_dia === undefined
+          ? row.precio_noche === null || row.precio_noche === undefined
+            ? null
+            : Number(row.precio_noche)
+          : Number(row.precio_dia),
       tipo_suelo: row.tipo_suelo == null ? null : row.tipo_suelo,
       techada: !!row.techada,
       iluminacion: !!row.iluminacion,


### PR DESCRIPTION
## Summary
- derive the base cancha price in the clubes model from `precio_dia`/`precio_noche` instead of selecting the legacy column
- update the cancha row mapper to compute `precio` from the differentiated pricing fields
- extend the mis canchas tests to validate the derived price using mocked database rows

## Testing
- npm test --prefix backend -- clubes.misCanchas.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e556190c84832fa6020d584534ca5a