### PR TITLE
Light- 0.3.71025.1619

### DIFF
--- a/backend/models/canchas.model.js
+++ b/backend/models/canchas.model.js
@@ -100,7 +100,6 @@ const CanchasModel = {
     nombre,
     deporte_id,
     capacidad = null,
-    precio = null,
     precio_dia = null,
     precio_noche = null,
     tipo_suelo = null,
@@ -113,14 +112,13 @@ const CanchasModel = {
 
     const [result] = await db.query(
       `INSERT INTO canchas
-       (club_id, nombre, deporte_id, capacidad, precio, precio_dia, precio_noche, tipo_suelo, techada, iluminacion, estado, imagen_url)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       (club_id, nombre, deporte_id, capacidad, precio_dia, precio_noche, tipo_suelo, techada, iluminacion, estado, imagen_url)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         club_id,
         nombre,
         deporte_id,
         capacidad === undefined ? null : capacidad,
-        precio === undefined ? null : precio,
         precio_dia === undefined ? null : precio_dia,
         precio_noche === undefined ? null : precio_noche,
         tipo_suelo === undefined ? null : tipo_suelo,
@@ -150,7 +148,7 @@ const CanchasModel = {
 
   listarPorClub: async (club_id) => {
     const [rows] = await db.query(
-      `SELECT cancha_id, club_id, nombre, deporte_id, capacidad, precio, precio_dia, precio_noche,
+      `SELECT cancha_id, club_id, nombre, deporte_id, capacidad, precio_dia, precio_noche,
               tipo_suelo, techada, iluminacion, estado, imagen_url
        FROM canchas
        WHERE club_id = ?
@@ -166,7 +164,6 @@ const CanchasModel = {
       nombre,
       deporte_id,
       capacidad,
-      precio,
       precio_dia,
       precio_noche,
       tipo_suelo,
@@ -202,7 +199,6 @@ const CanchasModel = {
       values.push(deporte_id);
     }
     setNullable('capacidad', capacidad === undefined ? undefined : capacidad);
-    setNullable('precio', precio === undefined ? undefined : precio);
     setNullable('precio_dia', precio_dia === undefined ? undefined : precio_dia);
     setNullable('precio_noche', precio_noche === undefined ? undefined : precio_noche);
     setNullable('tipo_suelo', tipo_suelo === undefined ? undefined : tipo_suelo);

--- a/backend/routes/clubes.routes.js
+++ b/backend/routes/clubes.routes.js
@@ -153,23 +153,25 @@ const buildCanchaPayload = (body = {}, { partial = false } = {}) => {
     payload.capacidad = capacidad === undefined ? null : capacidad;
   }
 
-  const precioBase = parseDecimal(body.precio, 'precio', { required: !partial });
-  if (precioBase !== undefined) {
-    payload.precio = precioBase;
+  const precioDiaProvided = body.precio_dia !== undefined;
+  const precioNocheProvided = body.precio_noche !== undefined;
+
+  if (!partial && !precioDiaProvided && !precioNocheProvided) {
+    throwValidationError('Debe especificar al menos uno de precio_dia o precio_noche');
   }
 
-  const precioDia = parseDecimal(body.precio_dia, 'precio_dia');
-  if (precioDia !== undefined) {
-    payload.precio_dia = precioDia;
-  } else if (!partial) {
-    payload.precio_dia = null;
+  if (precioDiaProvided) {
+    const precioDia = parseDecimal(body.precio_dia, 'precio_dia');
+    if (precioDia !== undefined) {
+      payload.precio_dia = precioDia;
+    }
   }
 
-  const precioNoche = parseDecimal(body.precio_noche, 'precio_noche');
-  if (precioNoche !== undefined) {
-    payload.precio_noche = precioNoche;
-  } else if (!partial) {
-    payload.precio_noche = null;
+  if (precioNocheProvided) {
+    const precioNoche = parseDecimal(body.precio_noche, 'precio_noche');
+    if (precioNoche !== undefined) {
+      payload.precio_noche = precioNoche;
+    }
   }
 
   const tipoSuelo = parseNullableString(body.tipo_suelo, 'tipo_suelo');

--- a/backend/tests/clubes.misCanchas.test.js
+++ b/backend/tests/clubes.misCanchas.test.js
@@ -87,10 +87,12 @@ describe('Rutas de Mis Canchas', () => {
     expect(ClubesModel.obtenerMisCanchas).toHaveBeenCalledWith(10);
   });
 
-  it('rechaza creación sin campos obligatorios', async () => {
+  it('rechaza creación sin precios', async () => {
     const app = buildApp();
 
-    const res = await request(app).post('/mis-canchas').send({ nombre: '' });
+    const res = await request(app)
+      .post('/mis-canchas')
+      .send({ nombre: 'Cancha sin precio', deporte_id: 2, capacidad: 10 });
 
     expect(res.status).toBe(400);
     expect(CanchasModel.crearCancha).not.toHaveBeenCalled();
@@ -107,7 +109,6 @@ describe('Rutas de Mis Canchas', () => {
         nombre: '  Cancha Central  ',
         deporte_id: '5',
         capacidad: '12',
-        precio: '1000.555',
         precio_dia: '1200.4',
         precio_noche: '',
         tipo_suelo: '  Cemento ',
@@ -122,7 +123,6 @@ describe('Rutas de Mis Canchas', () => {
       nombre: 'Cancha Central',
       deporte_id: 5,
       capacidad: 12,
-      precio: 1000.56,
       precio_dia: 1200.4,
       precio_noche: null,
       tipo_suelo: 'Cemento',
@@ -145,15 +145,15 @@ describe('Rutas de Mis Canchas', () => {
   it('actualiza cancha válida', async () => {
     const app = buildApp();
     CanchasModel.obtenerCanchaPorId.mockResolvedValue({ cancha_id: 1, club_id: 10 });
-    CanchasModel.actualizarCancha.mockResolvedValue({ cancha_id: 1, precio: 2000 });
+    CanchasModel.actualizarCancha.mockResolvedValue({ cancha_id: 1, precio_dia: 2000 });
 
     const res = await request(app)
       .patch('/mis-canchas/1')
-      .send({ precio: '2000', iluminacion: 1 });
+      .send({ precio_dia: '2000', iluminacion: 1 });
 
     expect(res.status).toBe(200);
     expect(CanchasModel.actualizarCancha).toHaveBeenCalledWith(1, {
-      precio: 2000,
+      precio_dia: 2000,
       iluminacion: true,
     });
   });


### PR DESCRIPTION
## Summary
- valida en las rutas de mis canchas que llegue precio_dia o precio_noche y elimina el campo base
- ajusta el modelo de canchas para persistir solo los precios por franja y derivar el precio calculado
- actualiza las pruebas de mis canchas para reflejar el nuevo contrato de precios

## Testing
- `npm test --prefix backend -- clubes.misCanchas.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68e564f101d0832fbcf5825662d1d2dc