### PR TITLE
Light- 0.3.71025.1730

### DIFF
--- a/backend/models/clubes.model.js
+++ b/backend/models/clubes.model.js
@@ -1,5 +1,6 @@
 const db = require('../config/db');
 const { normalizeLogoValue, prepareLogoValue } = require('../utils/logoStorage');
+const { normalizeCourtImage } = require('../utils/courtImage');
 
 const toNullableNumber = (value) => {
   if (value === undefined || value === null) return null;
@@ -173,7 +174,7 @@ const ClubesModel = {
       techada: !!row.techada,
       iluminacion: !!row.iluminacion,
       estado: row.estado || 'disponible',
-      imagen_url: row.imagen_url == null ? null : row.imagen_url,
+      imagen_url: normalizeCourtImage(row.imagen_url),
     }));
   },
 

--- a/backend/routes/clubes.routes.js
+++ b/backend/routes/clubes.routes.js
@@ -669,10 +669,14 @@ router.post('/mis-canchas/:cancha_id/imagen', uploadCanchaImagen, async (req, re
       return res.status(400).json({ mensaje: 'Debe adjuntar un archivo "imagen"' });
     }
 
-    const storedPath = await CanchasModel.actualizarImagen(canchaId, req.file);
+    await CanchasModel.actualizarImagen(canchaId, req.file);
     const cancha = await CanchasModel.obtenerCanchaPorId(canchaId);
 
-    res.json({ mensaje: 'Imagen actualizada', imagen_url: storedPath, cancha });
+    res.json({
+      mensaje: 'Imagen actualizada',
+      imagen_url: cancha ? cancha.imagen_url : null,
+      cancha,
+    });
   } catch (err) {
     if (err.statusCode === 400) {
       return res.status(400).json({ mensaje: err.message });

--- a/backend/server.js
+++ b/backend/server.js
@@ -3,7 +3,6 @@ const express = require('express');
 const cors = require('cors');
 const logger = require('./utils/logger');
 const { logosDir, logosPublicPath } = require('./utils/logoStorage');
-const CanchasModel = require('./models/canchas.model');
 const app = express();
 const PORT = process.env.PORT || 3006;
 const PasswordResetsModel = require('./models/passwordResets.model');
@@ -12,10 +11,6 @@ const PasswordResetsModel = require('./models/passwordResets.model');
 app.use(cors());
 app.use(express.json());
 app.use(logosPublicPath, express.static(logosDir));
-const canchasStatic = CanchasModel && CanchasModel._imagenes;
-if (canchasStatic && canchasStatic.dir && canchasStatic.publicPath) {
-  app.use(canchasStatic.publicPath, express.static(canchasStatic.dir));
-}
 const authRoutes = require('./routes/auth.routes');
 const usuariosRoutes = require('./routes/usuarios.routes');
 const clubesRoutes = require('./routes/clubes.routes');

--- a/backend/tests/clubes.misCanchas.test.js
+++ b/backend/tests/clubes.misCanchas.test.js
@@ -182,12 +182,12 @@ describe('Rutas de Mis Canchas', () => {
     const app = buildApp();
     CanchasModel.obtenerCanchaPorId
       .mockResolvedValueOnce({ cancha_id: 11, club_id: 10, imagen_url: null })
-      .mockResolvedValueOnce({ cancha_id: 11, club_id: 10, imagen_url: '/uploads/canchas/nueva.png' });
+      .mockResolvedValueOnce({ cancha_id: 11, club_id: 10, imagen_url: 'data:image/png;base64,AAA' });
 
-    CanchasModel.actualizarImagen.mockResolvedValue('/uploads/canchas/nueva.png');
+    CanchasModel.actualizarImagen.mockResolvedValue('data:image/png;base64,AAA');
 
     global.__testCanchaFile = {
-      buffer: Buffer.from('file'),
+      buffer: Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]),
       mimetype: 'image/png',
       originalname: 'foto.png',
     };
@@ -196,7 +196,7 @@ describe('Rutas de Mis Canchas', () => {
 
     expect(res.status).toBe(200);
     expect(CanchasModel.actualizarImagen).toHaveBeenCalledWith(11, global.__testCanchaFile);
-    expect(res.body).toHaveProperty('imagen_url', '/uploads/canchas/nueva.png');
+    expect(res.body.imagen_url).toMatch(/^data:image\//);
   });
 
   it('devuelve resumen de cancha', async () => {

--- a/backend/utils/courtImage.js
+++ b/backend/utils/courtImage.js
@@ -1,0 +1,153 @@
+const ASCII_SAFE_REGEX = /^[\x20-\x7E]+$/;
+const PATH_LIKE_REGEX = /^(?:\/?uploads\/canchas|https?:\/\/|\/)/i;
+const DATA_URI_REGEX = /^data:([^;]+);base64,([A-Za-z0-9+/=\s]+)$/i;
+const BASE64_REGEX = /^[A-Za-z0-9+/=]+$/;
+
+const formatError = (message) => {
+  const err = new Error(message);
+  err.statusCode = 400;
+  return err;
+};
+
+const detectMimeType = (buffer) => {
+  if (!Buffer.isBuffer(buffer) || buffer.length === 0) {
+    return null;
+  }
+
+  if (
+    buffer.length >= 8 &&
+    buffer[0] === 0x89 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x4e &&
+    buffer[3] === 0x47 &&
+    buffer[4] === 0x0d &&
+    buffer[5] === 0x0a &&
+    buffer[6] === 0x1a &&
+    buffer[7] === 0x0a
+  ) {
+    return 'image/png';
+  }
+
+  if (
+    buffer.length >= 3 &&
+    buffer[0] === 0xff &&
+    buffer[1] === 0xd8 &&
+    buffer[2] === 0xff
+  ) {
+    return 'image/jpeg';
+  }
+
+  if (
+    buffer.length >= 12 &&
+    buffer.toString('ascii', 0, 4) === 'RIFF' &&
+    buffer.toString('ascii', 8, 12) === 'WEBP'
+  ) {
+    return 'image/webp';
+  }
+
+  return 'application/octet-stream';
+};
+
+const bufferToDataUri = (buffer) => {
+  if (!Buffer.isBuffer(buffer) || buffer.length === 0) {
+    return null;
+  }
+  const mime = detectMimeType(buffer) || 'application/octet-stream';
+  return `data:${mime};base64,${buffer.toString('base64')}`;
+};
+
+const tryDecodeBase64 = (value) => {
+  const compact = value.replace(/\s+/g, '');
+  if (compact.length < 16 || compact.length % 4 !== 0) {
+    return null;
+  }
+  if (!BASE64_REGEX.test(compact)) {
+    return null;
+  }
+  try {
+    const decoded = Buffer.from(compact, 'base64');
+    return decoded.length > 0 ? decoded : null;
+  } catch (_err) {
+    return null;
+  }
+};
+
+const dataUriToBuffer = (value) => {
+  if (typeof value !== 'string') return null;
+  const match = value.trim().match(DATA_URI_REGEX);
+  if (!match) return null;
+  const base64Part = match[2].replace(/\s+/g, '');
+  try {
+    const buffer = Buffer.from(base64Part, 'base64');
+    return buffer.length > 0 ? buffer : null;
+  } catch (_err) {
+    return null;
+  }
+};
+
+const normalizeCourtImage = (value) => {
+  if (value == null) return null;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed || null;
+  }
+  if (!Buffer.isBuffer(value) || value.length === 0) {
+    return null;
+  }
+
+  const asciiCandidate = value.toString('utf8');
+  if (asciiCandidate && ASCII_SAFE_REGEX.test(asciiCandidate)) {
+    const trimmed = asciiCandidate.trim();
+    if (trimmed && PATH_LIKE_REGEX.test(trimmed)) {
+      return trimmed;
+    }
+  }
+
+  return bufferToDataUri(value);
+};
+
+const prepareCourtImage = (value) => {
+  if (value === undefined) {
+    return { shouldUpdate: false, value: undefined };
+  }
+  if (value === null) {
+    return { shouldUpdate: true, value: null };
+  }
+  if (Buffer.isBuffer(value)) {
+    return { shouldUpdate: true, value };
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return { shouldUpdate: true, value: null };
+    }
+
+    const dataUriBuffer = dataUriToBuffer(trimmed);
+    if (dataUriBuffer) {
+      return { shouldUpdate: true, value: dataUriBuffer };
+    }
+
+    if (PATH_LIKE_REGEX.test(trimmed) && ASCII_SAFE_REGEX.test(trimmed)) {
+      return { shouldUpdate: true, value: trimmed };
+    }
+
+    const base64Buffer = tryDecodeBase64(trimmed);
+    if (base64Buffer) {
+      return { shouldUpdate: true, value: base64Buffer };
+    }
+
+    throw formatError('imagen_url contiene un formato no soportado');
+  }
+  if (value && typeof value === 'object' && Buffer.isBuffer(value.buffer)) {
+    return { shouldUpdate: true, value: value.buffer };
+  }
+  throw formatError('imagen_url debe ser una cadena, Buffer o null');
+};
+
+module.exports = {
+  detectMimeType,
+  bufferToDataUri,
+  dataUriToBuffer,
+  normalizeCourtImage,
+  prepareCourtImage,
+};


### PR DESCRIPTION
## Summary
- add utilities to normalize and prepare court images, covering buffers, data URIs, and ASCII paths
- persist court images as blobs in MySQL and return normalized data URIs from court and club models
- drop filesystem storage for court images, update routes/tests, and keep only logo static hosting

## Testing
- npm test --prefix backend

------
https://chatgpt.com/codex/tasks/task_e_68e5716c931c832fa7f0f625a0fc5337