### PR TITLE
Qatar- 0.5.31126.0045

### DIFF
--- a/backend/utils/eventosRules.js
+++ b/backend/utils/eventosRules.js
@@ -18,6 +18,44 @@ const normalizeTipo = (value) => {
   return parsed ? parsed.toLowerCase() : null;
 };
 
+const normalizeNivelNombre = (value) => {
+  const normalized = normalizeString(value);
+  if (!normalized) return null;
+  const match = normalized.match(/\d+/);
+  if (match) return Number(match[0]);
+  if (/gratuito/i.test(normalized)) return 1;
+  if (/avanzado/i.test(normalized)) return 2;
+  if (/pro/i.test(normalized)) return 3;
+  return null;
+};
+
+const resolveClubNivelId = (club) => {
+  if (!club || typeof club !== 'object') return null;
+  const candidates = [
+    club.nivel_id,
+    club.nivelId,
+    club.nivel,
+    club?.nivel?.id,
+    club?.nivel?.nivel_id,
+    club?.nivel?.nivelId,
+    club?.plan?.nivel_id,
+    club?.plan?.nivelId,
+  ];
+
+  for (const candidate of candidates) {
+    const parsed = Number(candidate);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+
+  return (
+    normalizeNivelNombre(club.nivel_nombre) ??
+    normalizeNivelNombre(club.nivelNombre) ??
+    normalizeNivelNombre(club?.plan?.nombre)
+  );
+};
+
 const getLimitePorTipo = (tipo) => {
   if (!tipo) return null;
   return LIMITES_EQUIPOS_POR_TIPO[tipo] ?? null;
@@ -47,10 +85,16 @@ const validateTipo = (tipo) => {
 
 const validateClubPermisoTipo = (tipo, club) => {
   if (!tipo || !club) return;
-  if (['torneo', 'copa'].includes(tipo) && Number(club.nivel_id) < 2) {
-    const error = new Error('El club no tiene nivel suficiente para crear torneos o copas');
-    error.statusCode = 403;
-    throw error;
+  if (['torneo', 'copa'].includes(tipo)) {
+    const nivelId = resolveClubNivelId(club);
+    const normalizedNivel = Number.isFinite(nivelId) && nivelId > 0 ? nivelId : 1;
+    if (normalizedNivel < 2) {
+      const error = new Error(
+        'El club no tiene nivel suficiente para crear torneos o copas'
+      );
+      error.statusCode = 403;
+      throw error;
+    }
   }
 };
 
@@ -98,6 +142,7 @@ module.exports = {
   TIPOS_EVENTO,
   LIMITES_EQUIPOS_POR_TIPO,
   normalizeTipo,
+  resolveClubNivelId,
   getLimitePorTipo,
   validateEstado,
   validateTipo,


### PR DESCRIPTION
### Motivation
- Resolver el error 403 al intentar crear un Evento de tipo `torneo`/`copa` por inconsistencias en cómo se obtiene el nivel del club desde distintos objetos/propiedades.  
- Asegurar que la creación de torneos y copas esté permitida para clubes con nivel 2 o superior incluso cuando el campo de nivel venga en formatos/propiedades distintos.  

### Description
- Añadido `resolveClubNivelId` y `normalizeNivelNombre` en `backend/utils/eventosRules.js` para extraer el `nivel_id` desde múltiples rutas (`nivel_id`, `nivelId`, `nivel`, `nivel_nombre`, `plan.nombre`, etc.) y parsear nombres de plan como "Avanzado"/"Pro" a números.  
- Reemplazada la comprobación directa de `club.nivel_id` en `validateClubPermisoTipo` por la nueva resolución robusta y por defecto a nivel `1` cuando no se puede derivar un valor válido.  
- Mantiene la misma respuesta de error (`403` con mensaje `El club no tiene nivel suficiente para crear torneos o copas`) cuando el nivel resuelto es menor que `2`.  
- Exporta `resolveClubNivelId` desde el módulo para facilitar futuras validaciones y consistencia.  

### Testing
- No se ejecutaron pruebas automáticas durante este cambio.  
- Verificación estática del código y revisión local de los flujos de creación de evento en `backend/controllers/eventos.controller.js` que usan `validateClubPermisoTipo` para asegurarse de la integración correcta.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d79787348832f88ea10aa2556595f)